### PR TITLE
feat(core): support generic command payloads

### DIFF
--- a/packages/core/test/commandBus.test.ts
+++ b/packages/core/test/commandBus.test.ts
@@ -1,13 +1,23 @@
 import { describe, it, expect } from 'vitest';
-import { CommandBus, Command } from '../src/commands/commandBus';
+import { CommandBus, CommandOf } from '../src/commands/commandBus';
+
+interface CounterCommands {
+  inc: {};
+  'undo:inc': {};
+}
 
 describe('CommandBus', () => {
   it('dispatches and undoes commands', async () => {
-    const bus = new CommandBus();
+    const bus = new CommandBus<CounterCommands>();
     let count = 0;
-    bus.register('inc', () => { count++; });
-    bus.register('undo:inc', () => { count--; });
-    await bus.dispatch({ id: 'inc', args: {} });
+    bus.register('inc', () => {
+      count++;
+    });
+    bus.register('undo:inc', () => {
+      count--;
+    });
+    const cmd: CommandOf<CounterCommands> = { id: 'inc', args: {} };
+    await bus.dispatch(cmd);
     expect(count).toBe(1);
     bus.undo();
     expect(count).toBe(0);

--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,6 +1,6 @@
-import { Command } from '@airdraw/core';
+import { AppCommand } from '../commands';
 
-export async function parsePrompt(prompt: string): Promise<Command[]> {
+export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
   // Very small rule-based stub
   if (/undo/i.test(prompt)) return [{ id: 'undo', args: {} }];
   if (/red/i.test(prompt)) return [{ id: 'setColor', args: { hex: '#ff0000' } }];

--- a/packages/web/src/commands.ts
+++ b/packages/web/src/commands.ts
@@ -1,0 +1,8 @@
+import { CommandOf } from '@airdraw/core';
+
+export interface AppCommands {
+  setColor: { hex: string };
+  undo: {};
+}
+
+export type AppCommand = CommandOf<AppCommands>;

--- a/packages/web/src/components/RadialPalette.tsx
+++ b/packages/web/src/components/RadialPalette.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Command } from '@airdraw/core';
+import { AppCommand } from '../commands';
 
-interface PaletteItem { label: string; command: Command }
+interface PaletteItem { label: string; command: AppCommand }
 const items: PaletteItem[] = [
   { label: 'Black', command: { id: 'setColor', args: { hex: '#000000' } } },
   { label: 'Red', command: { id: 'setColor', args: { hex: '#ff0000' } } },
@@ -10,7 +10,7 @@ const items: PaletteItem[] = [
 
 export interface RadialPaletteProps {
   visible: boolean;
-  onSelect(cmd: Command): void;
+  onSelect(cmd: AppCommand): void;
 }
 
 export function RadialPalette({ visible, onSelect }: RadialPaletteProps) {

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useHandTracking } from './hooks/useHandTracking';
 import { RadialPalette } from './components/RadialPalette';
-import { CommandBus, Command } from '@airdraw/core';
+import { CommandBus } from '@airdraw/core';
 import { parsePrompt } from './ai/copilot';
+import { AppCommand, AppCommands } from './commands';
 
-const bus = new CommandBus();
+const bus = new CommandBus<AppCommands>();
 bus.register('setColor', async args => console.log('setColor', args));
 bus.register('undo', () => console.log('undo'));
 
@@ -13,7 +14,7 @@ function App() {
   const { videoRef, gesture } = useHandTracking();
   const [palette, setPalette] = useState(false);
 
-  const handleCommand = (cmd: Command) => {
+  const handleCommand = (cmd: AppCommand) => {
     bus.dispatch(cmd);
     setPalette(false);
   };


### PR DESCRIPTION
## Summary
- use generics for Command and CommandHandler and provide helpers for typed command maps
- update command bus tests and web handlers to use typed commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a24542794832899447140c2b36f14