### PR TITLE
Integrate MediaPipe hand tracking with cleanup and error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -446,6 +446,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@mediapipe/hands": {
+      "version": "0.4.1675469240",
+      "resolved": "https://registry.npmjs.org/@mediapipe/hands/-/hands-0.4.1675469240.tgz",
+      "integrity": "sha512-GxoZvL1mmhJxFxjuyj7vnC++JIuInGznHBin5c7ZSq/RbcnGyfEcJrkM/bMu5K1Mz/2Ko+vEX6/+wewmEHPrHg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.46.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.46.2.tgz",
@@ -1591,7 +1597,10 @@
     },
     "packages/web": {
       "name": "@airdraw/web",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dependencies": {
+        "@mediapipe/hands": "^0.4.1675469240"
+      }
     }
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@airdraw/web",
   "version": "0.1.0",
-  "main": "src/main.tsx"
+  "main": "src/main.tsx",
+  "dependencies": {
+    "@mediapipe/hands": "^0.4.1675469240"
+  }
 }

--- a/packages/web/src/hooks/useHandTracking.ts
+++ b/packages/web/src/hooks/useHandTracking.ts
@@ -1,27 +1,91 @@
 import { useEffect, useRef, useState } from 'react';
 import { GestureFSM, HandInput, Gesture } from '@airdraw/core';
 
+type Landmark = { x: number; y: number };
+
+const dist = (a: Landmark, b: Landmark) => Math.hypot(a.x - b.x, a.y - b.y);
+
+function calcPinch(lm: Landmark[]): number {
+  const thumb = lm[4];
+  const index = lm[8];
+  const scale = dist(lm[0], lm[5]) || 1;
+  return Math.max(0, Math.min(1, 1 - dist(thumb, index) / scale));
+}
+
+function countFingers(lm: Landmark[]): number {
+  const up = (tip: number, pip: number) => (lm[tip].y < lm[pip].y ? 1 : 0);
+  let fingers = up(8, 6) + up(12, 10) + up(16, 14) + up(20, 18);
+  if (lm[4].x < lm[3].x) fingers++;
+  return fingers;
+}
+
 export function useHandTracking() {
   const videoRef = useRef<HTMLVideoElement>(null);
   const [gesture, setGesture] = useState<Gesture>('idle');
+  const [error, setError] = useState<Error | null>(null);
   const fsmRef = useRef(new GestureFSM());
 
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
-    navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
-      video.srcObject = stream;
-      video.play();
-      const loop = () => {
-        // Placeholder: real implementation would run model here
-        const input: HandInput = { pinch: 0, fingers: 5 };
-        const g = fsmRef.current.update(input);
-        setGesture(g);
-        requestAnimationFrame(loop);
-      };
-      loop();
-    }).catch(err => console.warn('camera error', err));
+
+    let raf = 0;
+    let stream: MediaStream | null = null;
+    let hands: any;
+    let active = true;
+
+    async function init() {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ video: true });
+        if (!active) return;
+        video.srcObject = stream;
+        await video.play();
+
+        const m = await import('@mediapipe/hands');
+        hands = new m.Hands({
+          locateFile: (file: string) =>
+            `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}`
+        });
+        hands.setOptions({ maxNumHands: 1, selfieMode: true });
+
+        hands.onResults((res: any) => {
+          if (!res.multiHandLandmarks || !res.multiHandLandmarks.length) {
+            const g = fsmRef.current.update({ pinch: 0, fingers: 0 });
+            setGesture(g);
+            return;
+          }
+          const lm = res.multiHandLandmarks[0] as Landmark[];
+          const input: HandInput = {
+            pinch: calcPinch(lm),
+            fingers: countFingers(lm)
+          };
+          const g = fsmRef.current.update(input);
+          setGesture(g);
+        });
+
+        const loop = async () => {
+          if (!active) return;
+          if (video.readyState >= 2) {
+            await hands.send({ image: video });
+          }
+          raf = requestAnimationFrame(loop);
+        };
+        loop();
+      } catch (err) {
+        console.error('camera error', err);
+        if (active) setError(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
+    init();
+
+    return () => {
+      active = false;
+      if (raf) cancelAnimationFrame(raf);
+      if (stream) stream.getTracks().forEach(t => t.stop());
+      if (hands?.close) hands.close();
+    };
   }, []);
 
-  return { videoRef, gesture };
+  return { videoRef, gesture, error };
 }
+

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -10,13 +10,17 @@ bus.register('setColor', async args => console.log('setColor', args));
 bus.register('undo', () => console.log('undo'));
 
 function App() {
-  const { videoRef, gesture } = useHandTracking();
+  const { videoRef, gesture, error } = useHandTracking();
   const [palette, setPalette] = useState(false);
 
   const handleCommand = (cmd: Command) => {
     bus.dispatch(cmd);
     setPalette(false);
   };
+
+  if (error) {
+    return <div>Camera error: {error.message}</div>;
+  }
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- Replace placeholder hand tracking with MediaPipe Hands to derive pinch and finger data for gestures.
- Add cleanup for video streams and animation frames and expose camera errors through hook state.
- Display camera failures in the app and add MediaPipe Hands dependency.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2458408c8328aaa9eeb193ad3187