### PR TITLE
feat: add LLM copilot with fallback

### DIFF
--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -1,0 +1,29 @@
+# Copilot Prompts
+
+The web client includes a small **AI copilot** that turns natural language into drawing commands. By default it calls an LLM (such as OpenAI) which returns structured `Command` objects.
+
+Set the `OPENAI_API_KEY` environment variable to enable the LLM parser.
+
+## Examples
+
+Prompt:
+
+> undo the last action
+
+Returns:
+
+```json
+[{ "id": "undo", "args": {} }]
+```
+
+Prompt:
+
+> make it red
+
+Returns:
+
+```json
+[{ "id": "setColor", "args": { "hex": "#ff0000" } }]
+```
+
+If the LLM is unreachable, a lightweight rule-based fallback handles a few simple prompts like the ones above.

--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,8 +1,49 @@
 import { Command } from '@airdraw/core';
 
+// Calls an LLM to parse a natural language prompt into Command objects.
+// Falls back to a small rule-based parser when the API is unavailable.
 export async function parsePrompt(prompt: string): Promise<Command[]> {
-  // Very small rule-based stub
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (apiKey) {
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'Translate the user request into a JSON array of command objects with id and args fields.',
+            },
+            { role: 'user', content: prompt },
+          ],
+          response_format: { type: 'json_object' },
+        }),
+      });
+      if (res.ok) {
+        const json = await res.json();
+        const content = json.choices?.[0]?.message?.content;
+        if (content) {
+          const parsed = JSON.parse(content);
+          if (Array.isArray(parsed)) return parsed;
+          if (Array.isArray(parsed.commands)) return parsed.commands;
+        }
+      }
+    } catch {
+      // swallow error and use fallback
+    }
+  }
+  return ruleBasedParser(prompt);
+}
+
+function ruleBasedParser(prompt: string): Command[] {
   if (/undo/i.test(prompt)) return [{ id: 'undo', args: {} }];
   if (/red/i.test(prompt)) return [{ id: 'setColor', args: { hex: '#ff0000' } }];
   return [];
 }
+

--- a/packages/web/test/copilot.test.ts
+++ b/packages/web/test/copilot.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { parsePrompt } from '../src/ai/copilot';
+
+const originalFetch = global.fetch;
+const originalKey = process.env.OPENAI_API_KEY;
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  process.env.OPENAI_API_KEY = originalKey;
+  vi.restoreAllMocks();
+});
+
+describe('parsePrompt', () => {
+  it('returns commands from LLM API when available', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [
+            {
+              message: {
+                content: JSON.stringify([{ id: 'undo', args: {} }]),
+              },
+            },
+          ],
+        }),
+    } as any);
+    const cmds = await parsePrompt('undo the last action');
+    expect(cmds).toEqual([{ id: 'undo', args: {} }]);
+    expect(global.fetch).toHaveBeenCalled();
+  });
+
+  it('falls back to rule-based parser on error', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    global.fetch = vi.fn().mockRejectedValue(new Error('network'));
+    const cmds = await parsePrompt('make it red');
+    expect(cmds).toEqual([{ id: 'setColor', args: { hex: '#ff0000' } }]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- Use OpenAI chat completions to translate prompts into Command objects
- Fallback to a tiny rule-based parser when the API is unavailable
- Document prompt examples and add tests for LLM and fallback paths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a245d99bc83289125aa796dc076cc