### PR TITLE
feat(core): add brush engine timestamp default and reset

### DIFF
--- a/packages/core/src/draw/brushEngine.ts
+++ b/packages/core/src/draw/brushEngine.ts
@@ -9,8 +9,10 @@ export class BrushEngine {
   private filterX: OneEuroFilter;
   private filterY: OneEuroFilter;
   private current?: BrushConfig;
+  private filterCfg: { minCutoff: number; beta: number; dcutoff: number };
 
   constructor(filterCfg = { minCutoff: 1.0, beta: 0.0, dcutoff: 1.0 }) {
+    this.filterCfg = filterCfg;
     this.filterX = new OneEuroFilter(filterCfg);
     this.filterY = new OneEuroFilter(filterCfg);
   }
@@ -20,7 +22,7 @@ export class BrushEngine {
     this.points = [];
   }
 
-  addPoint(p: Vec2, t: number) {
+  addPoint(p: Vec2, t = performance.now()) {
     const x = this.filterX.filter(p.x, t);
     const y = this.filterY.filter(p.y, t);
     this.points.push({ x, y });
@@ -32,5 +34,12 @@ export class BrushEngine {
     this.current = undefined;
     this.points = [];
     return stroke;
+  }
+
+  reset() {
+    this.filterX = new OneEuroFilter(this.filterCfg);
+    this.filterY = new OneEuroFilter(this.filterCfg);
+    this.points = [];
+    this.current = undefined;
   }
 }

--- a/packages/core/test/brushEngine.test.ts
+++ b/packages/core/test/brushEngine.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BrushEngine } from '../src/draw/brushEngine';
+
+const brush = { type: 'pencil', size: 1, opacity: 1, hardness: 1 };
+
+describe('BrushEngine', () => {
+  it('records a stroke between start and end', () => {
+    const engine = new BrushEngine();
+    const spy = vi.spyOn(performance, 'now').mockReturnValue(0);
+    engine.start(brush);
+    engine.addPoint({ x: 0, y: 0 });
+    engine.addPoint({ x: 10, y: 0 }, 16);
+    const stroke = engine.end();
+    spy.mockRestore();
+    expect(stroke.brush).toEqual(brush);
+    expect(stroke.points.length).toBe(2);
+  });
+
+  it('smooths noisy input using one-euro filter', () => {
+    const engine = new BrushEngine({ minCutoff: 1, beta: 0, dcutoff: 1 });
+    engine.start(brush);
+    const times = [0, 16, 32, 48];
+    const values = [0, 10, 0, 10];
+    values.forEach((v, i) => engine.addPoint({ x: v, y: 0 }, times[i]));
+    const stroke = engine.end();
+    expect(stroke.points[1].x).toBeLessThan(10);
+  });
+
+  it('can reset filters between strokes', () => {
+    const engine = new BrushEngine();
+    engine.start(brush);
+    engine.addPoint({ x: 0, y: 0 }, 0);
+    engine.addPoint({ x: 10, y: 0 }, 16);
+    engine.end();
+    engine.start(brush);
+    engine.addPoint({ x: 10, y: 0 }, 32);
+    const stroke1 = engine.end();
+    expect(stroke1.points[0].x).toBeLessThan(10);
+    engine.reset();
+    engine.start(brush);
+    engine.addPoint({ x: 10, y: 0 }, 0);
+    const stroke2 = engine.end();
+    expect(stroke2.points[0].x).toBe(10);
+  });
+});


### PR DESCRIPTION
## Summary
- default brush engine points to `performance.now()` when timestamp omitted
- expose `reset()` to clear filters and state between strokes
- test brush engine stroke workflow, one-euro smoothing, and reset

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2461a8788328b936606342e1c185