### PR TITLE
feat(core): configurable gesture FSM with typed events

### DIFF
--- a/packages/core/src/vision/gestureFsm.ts
+++ b/packages/core/src/vision/gestureFsm.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from 'events';
-
 export type Gesture = 'idle' | 'draw' | 'palette' | 'fist';
 
 export interface HandInput {
@@ -7,12 +5,49 @@ export interface HandInput {
   fingers: number; // number of extended fingers
 }
 
-export class GestureFSM extends EventEmitter {
+export interface GestureFsmConfig {
+  /** Pinch value above which a draw gesture is detected */
+  pinchThreshold?: number;
+  /** Maximum number of fingers extended for a draw gesture */
+  fingerThreshold?: number;
+}
+
+export interface GestureFsmEvents {
+  change: (g: Gesture) => void;
+}
+
+const DEFAULT_CONFIG: Required<GestureFsmConfig> = {
+  pinchThreshold: 0.8,
+  fingerThreshold: 2,
+};
+
+export class GestureFSM {
   private state: Gesture = 'idle';
+  private config: Required<GestureFsmConfig>;
+  private listeners: { [K in keyof GestureFsmEvents]?: GestureFsmEvents[K][] } = {};
+
+  constructor(config: GestureFsmConfig = {}) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  on<K extends keyof GestureFsmEvents>(event: K, listener: GestureFsmEvents[K]): void {
+    (this.listeners[event] ||= []).push(listener);
+  }
+
+  off<K extends keyof GestureFsmEvents>(event: K, listener: GestureFsmEvents[K]): void {
+    const arr = this.listeners[event];
+    if (!arr) return;
+    const idx = arr.indexOf(listener);
+    if (idx >= 0) arr.splice(idx, 1);
+  }
+
+  private emit<K extends keyof GestureFsmEvents>(event: K, ...args: Parameters<GestureFsmEvents[K]>): void {
+    this.listeners[event]?.forEach(fn => fn(...args));
+  }
 
   update(input: HandInput): Gesture {
     let next: Gesture = this.state;
-    if (input.pinch > 0.8 && input.fingers <= 2) next = 'draw';
+    if (input.pinch > this.config.pinchThreshold && input.fingers <= this.config.fingerThreshold) next = 'draw';
     else if (input.fingers === 5) next = 'palette';
     else if (input.fingers === 0) next = 'fist';
     else next = 'idle';

--- a/packages/core/test/gestureFsm.test.ts
+++ b/packages/core/test/gestureFsm.test.ts
@@ -7,4 +7,10 @@ describe('GestureFSM', () => {
     const g = fsm.update({ pinch: 0.9, fingers: 2 });
     expect(g).toBe('draw');
   });
+
+  it('supports custom thresholds', () => {
+    const fsm = new GestureFSM({ pinchThreshold: 0.5, fingerThreshold: 3 });
+    const g = fsm.update({ pinch: 0.6, fingers: 3 });
+    expect(g).toBe('draw');
+  });
 });


### PR DESCRIPTION
## Summary
- add `GestureFsmConfig` to customize pinch and finger thresholds
- replace untyped EventEmitter with a typed event interface
- test GestureFSM with custom thresholds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a246e995c8328a01211580bc67503