### PR TITLE
feat: allow configurable radial palette

### DIFF
--- a/packages/web/src/components/RadialPalette.tsx
+++ b/packages/web/src/components/RadialPalette.tsx
@@ -1,25 +1,28 @@
 import React from 'react';
 import { Command } from '@airdraw/core';
 
-interface PaletteItem { label: string; command: Command }
-const items: PaletteItem[] = [
-  { label: 'Black', command: { id: 'setColor', args: { hex: '#000000' } } },
-  { label: 'Red', command: { id: 'setColor', args: { hex: '#ff0000' } } },
-  { label: 'Undo', command: { id: 'undo', args: {} } }
-];
+export interface PaletteItem {
+  label: string;
+  command: Command;
+}
 
 export interface RadialPaletteProps {
   visible: boolean;
+  items: PaletteItem[];
   onSelect(cmd: Command): void;
 }
 
-export function RadialPalette({ visible, onSelect }: RadialPaletteProps) {
+export function RadialPalette({ visible, items, onSelect }: RadialPaletteProps) {
   if (!visible) return null;
   return (
-    <div className="radial-palette">
+    <ul className="radial-palette" role="menu" aria-label="Radial palette">
       {items.map(it => (
-        <button key={it.label} onClick={() => onSelect(it.command)}>{it.label}</button>
+        <li key={it.label} role="none">
+          <button role="menuitem" onClick={() => onSelect(it.command)}>
+            {it.label}
+          </button>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { useHandTracking } from './hooks/useHandTracking';
-import { RadialPalette } from './components/RadialPalette';
+import { RadialPalette, PaletteItem } from './components/RadialPalette';
 import { CommandBus, Command } from '@airdraw/core';
 import { parsePrompt } from './ai/copilot';
 
@@ -12,6 +12,15 @@ bus.register('undo', () => console.log('undo'));
 function App() {
   const { videoRef, gesture } = useHandTracking();
   const [palette, setPalette] = useState(false);
+  /**
+   * Palette items passed to the RadialPalette component. Consumers can
+   * customize the palette by supplying a different array.
+   */
+  const items: PaletteItem[] = [
+    { label: 'Black', command: { id: 'setColor', args: { hex: '#000000' } } },
+    { label: 'Red', command: { id: 'setColor', args: { hex: '#ff0000' } } },
+    { label: 'Undo', command: { id: 'undo', args: {} } }
+  ];
 
   const handleCommand = (cmd: Command) => {
     bus.dispatch(cmd);
@@ -21,7 +30,7 @@ function App() {
   return (
     <div>
       <video ref={videoRef} style={{ display: 'none' }} />
-      <RadialPalette visible={palette} onSelect={handleCommand} />
+      <RadialPalette visible={palette} items={items} onSelect={handleCommand} />
       <div>Gesture: {gesture}</div>
     </div>
   );


### PR DESCRIPTION
## Summary
- make `RadialPalette` accept an `items` prop and render a semantic list with ARIA roles
- pass configurable palette items from `main.tsx` with inline documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a24719fa083289edd81f94e14480e