### PR TITLE
feat: add prompt input and async command parsing

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -12,10 +12,27 @@ bus.register('undo', () => console.log('undo'));
 function App() {
   const { videoRef, gesture } = useHandTracking();
   const [palette, setPalette] = useState(false);
+  const [prompt, setPrompt] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleCommand = (cmd: Command) => {
     bus.dispatch(cmd);
     setPalette(false);
+  };
+
+  const handlePrompt = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const cmds = await parsePrompt(prompt);
+      cmds.forEach(cmd => bus.dispatch(cmd));
+      setPrompt('');
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -23,6 +40,16 @@ function App() {
       <video ref={videoRef} style={{ display: 'none' }} />
       <RadialPalette visible={palette} onSelect={handleCommand} />
       <div>Gesture: {gesture}</div>
+      <input
+        value={prompt}
+        onChange={e => setPrompt(e.target.value)}
+        placeholder="Ask the copilot"
+      />
+      <button onClick={handlePrompt} disabled={loading}>
+        Send
+      </button>
+      {loading && <div>Parsing...</div>}
+      {error && <div>Error: {error}</div>}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- allow entering prompts in App and parse them into commands
- handle async parsing with loading and error states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a24764ac0832898524786484d3b84