### PR TITLE
Await undo/redo and update tests

### DIFF
--- a/packages/core/src/commands/commandBus.ts
+++ b/packages/core/src/commands/commandBus.ts
@@ -24,17 +24,17 @@ export class CommandBus {
     this.redoStack = [];
   }
 
-  undo() {
+  async undo(): Promise<void> {
     const cmd = this.undoStack.pop();
     if (!cmd) return;
     const handler = this.handlers.get(`undo:${cmd.id}`);
-    if (handler) handler(cmd.args);
+    if (handler) await handler(cmd.args);
     this.redoStack.push(cmd);
   }
 
-  redo() {
+  async redo(): Promise<void> {
     const cmd = this.redoStack.pop();
     if (!cmd) return;
-    this.dispatch(cmd);
+    await this.dispatch(cmd);
   }
 }

--- a/packages/core/test/commandBus.test.ts
+++ b/packages/core/test/commandBus.test.ts
@@ -2,14 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { CommandBus, Command } from '../src/commands/commandBus';
 
 describe('CommandBus', () => {
-  it('dispatches and undoes commands', async () => {
+  it('dispatches, undoes, and redoes commands', async () => {
     const bus = new CommandBus();
     let count = 0;
     bus.register('inc', () => { count++; });
     bus.register('undo:inc', () => { count--; });
     await bus.dispatch({ id: 'inc', args: {} });
     expect(count).toBe(1);
-    bus.undo();
+    await bus.undo();
     expect(count).toBe(0);
+    await bus.redo();
+    expect(count).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- make CommandBus undo/redo asynchronous and return `Promise<void>`
- await handler in `undo` and `dispatch` in `redo`
- update command bus tests to await undo/redo and cover redo path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a247e9f408328a6e8380c73a08a76