### PR TITLE
refactor: use typed emitter for gestures

### DIFF
--- a/packages/core/src/vision/gestureFsm.ts
+++ b/packages/core/src/vision/gestureFsm.ts
@@ -1,14 +1,48 @@
-import { EventEmitter } from 'events';
-
 export type Gesture = 'idle' | 'draw' | 'palette' | 'fist';
 
 export interface HandInput {
   pinch: number; // 0-1
   fingers: number; // number of extended fingers
 }
+type Listener<Args extends any[]> = (...args: Args) => void;
 
-export class GestureFSM extends EventEmitter {
+interface Emitter<Events extends Record<string, any[]>> {
+  on<E extends keyof Events>(event: E, listener: Listener<Events[E]>): () => void;
+  emit<E extends keyof Events>(event: E, ...args: Events[E]): void;
+}
+
+function createEmitter<Events extends Record<string, any[]>>(): Emitter<Events> {
+  const listeners: { [K in keyof Events]?: Listener<Events[K]>[] } = {};
+  return {
+    on(event, listener) {
+      (listeners[event] ||= []).push(listener);
+      return () => {
+        const arr = listeners[event];
+        if (!arr) return;
+        listeners[event] = arr.filter(l => l !== listener);
+      };
+    },
+    emit(event, ...args) {
+      listeners[event]?.forEach(l => l(...args));
+    },
+  };
+}
+
+type GestureEvents = {
+  change: [Gesture];
+};
+
+export class GestureFSM {
   private state: Gesture = 'idle';
+  private emitter = createEmitter<GestureEvents>();
+
+  on<E extends keyof GestureEvents>(event: E, listener: Listener<GestureEvents[E]>): () => void {
+    return this.emitter.on(event, listener);
+  }
+
+  private emit<E extends keyof GestureEvents>(event: E, ...args: GestureEvents[E]): void {
+    this.emitter.emit(event, ...args);
+  }
 
   update(input: HandInput): Gesture {
     let next: Gesture = this.state;

--- a/packages/core/test/gestureFsm.test.ts
+++ b/packages/core/test/gestureFsm.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { GestureFSM } from '../src/vision/gestureFsm';
+import { GestureFSM, Gesture } from '../src/vision/gestureFsm';
 
 describe('GestureFSM', () => {
-  it('detects draw gesture', () => {
+  it('emits change event for draw gesture', () => {
     const fsm = new GestureFSM();
-    const g = fsm.update({ pinch: 0.9, fingers: 2 });
-    expect(g).toBe('draw');
+    let emitted: Gesture | undefined;
+    fsm.on('change', g => { emitted = g; });
+    fsm.update({ pinch: 0.9, fingers: 2 });
+    expect(emitted).toBe('draw');
   });
 });

--- a/packages/web/src/hooks/useHandTracking.ts
+++ b/packages/web/src/hooks/useHandTracking.ts
@@ -9,18 +9,19 @@ export function useHandTracking() {
   useEffect(() => {
     const video = videoRef.current;
     if (!video) return;
+    const off = fsmRef.current.on('change', setGesture);
     navigator.mediaDevices.getUserMedia({ video: true }).then(stream => {
       video.srcObject = stream;
       video.play();
       const loop = () => {
         // Placeholder: real implementation would run model here
         const input: HandInput = { pinch: 0, fingers: 5 };
-        const g = fsmRef.current.update(input);
-        setGesture(g);
+        fsmRef.current.update(input);
         requestAnimationFrame(loop);
       };
       loop();
     }).catch(err => console.warn('camera error', err));
+    return () => off();
   }, []);
 
   return { videoRef, gesture };


### PR DESCRIPTION
## Summary
- replace Node's EventEmitter in the gesture FSM with a small typed emitter
- subscribe to gesture changes via typed events in the web hand-tracking hook
- add test covering gesture change event emission

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a24813bf88328b772c755687209ed