### PR TITLE
Reset OneEuroFilter between brush strokes

### DIFF
--- a/packages/core/src/draw/brushEngine.ts
+++ b/packages/core/src/draw/brushEngine.ts
@@ -18,6 +18,8 @@ export class BrushEngine {
   start(config: BrushConfig) {
     this.current = config;
     this.points = [];
+    this.filterX.reset();
+    this.filterY.reset();
   }
 
   addPoint(p: Vec2, t: number) {

--- a/packages/core/src/vision/oneEuro.ts
+++ b/packages/core/src/vision/oneEuro.ts
@@ -9,6 +9,11 @@ export class OneEuroFilter {
   private dPrev?: number;
   constructor(private config: OneEuroConfig) {}
 
+  reset() {
+    this.prev = undefined;
+    this.dPrev = undefined;
+  }
+
   private alpha(t_e: number, cutoff: number) {
     const tau = 1 / (2 * Math.PI * cutoff);
     return 1 / (1 + tau / t_e);

--- a/packages/core/test/brushEngine.test.ts
+++ b/packages/core/test/brushEngine.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { BrushEngine } from '../src/draw/brushEngine';
+
+const brush = { type: 'basic', size: 1, opacity: 1, hardness: 1 };
+
+describe('BrushEngine', () => {
+  it('starts new strokes from unfiltered positions', () => {
+    const engine = new BrushEngine();
+
+    engine.start(brush);
+    engine.addPoint({ x: 0, y: 0 }, 0);
+    engine.addPoint({ x: 10, y: 10 }, 1);
+    engine.end();
+
+    engine.start(brush);
+    engine.addPoint({ x: 100, y: 100 }, 2);
+    const stroke = engine.end();
+
+    expect(stroke.points[0]).toEqual({ x: 100, y: 100 });
+  });
+});


### PR DESCRIPTION
## Summary
- add reset method to OneEuroFilter to clear previous state
- reset OneEuroFilter instances when starting a new brush stroke
- test that new strokes begin from unfiltered positions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a248241d48328b6f14562210ff1a6