### PR TITLE
docs: reflow README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # AirDraw
 
-AirDraw is an AI-assisted webcam drawing tool that lets users draw in mid-air using hand gestures. This repository contains a TypeScript monorepo with packages for core algorithms, the web client, optional server, and more. See `docs/` for product brief, design, and build plan.
+AirDraw is an AI-assisted webcam drawing tool that lets users draw in mid-air
+using hand gestures. This repository contains a TypeScript monorepo with
+packages for core algorithms, the web client, optional server, and more. See
+`docs/` for product brief, design, and build plan.


### PR DESCRIPTION
## Summary
- reflow README paragraph to keep “TypeScript” unbroken and cleanly wrap lines

## Testing
- `npx -y markdownlint-cli README.md`
- `npx -y marked README.md`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a2484213c832885b0bb0131d4f15c