### PR TITLE
refactor: typed command bus with undo fallback

### DIFF
--- a/packages/core/test/commandBus.test.ts
+++ b/packages/core/test/commandBus.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { CommandBus, Command } from '../src/commands/commandBus';
+import { CommandBus } from '../src/commands/commandBus';
 
 describe('CommandBus', () => {
   it('dispatches and undoes commands', async () => {
-    const bus = new CommandBus();
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
     let count = 0;
     bus.register('inc', () => { count++; });
     bus.register('undo:inc', () => { count--; });
@@ -11,5 +12,34 @@ describe('CommandBus', () => {
     expect(count).toBe(1);
     bus.undo();
     expect(count).toBe(0);
+  });
+
+  it('redos commands without losing handlers', async () => {
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
+    let count = 0;
+    bus.register('inc', () => { count++; });
+    bus.register('undo:inc', () => { count--; });
+    await bus.dispatch({ id: 'inc', args: {} });
+    expect(count).toBe(1);
+    bus.undo();
+    expect(count).toBe(0);
+    await bus.redo();
+    expect(count).toBe(1);
+    bus.undo();
+    expect(count).toBe(0);
+  });
+
+  it('restores undo state when no undo handler is registered', async () => {
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
+    let count = 0;
+    bus.register('inc', () => { count++; });
+    await bus.dispatch({ id: 'inc', args: {} });
+    expect(count).toBe(1);
+    bus.undo();
+    expect(count).toBe(1);
+    await bus.redo();
+    expect(count).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- add generic CommandMap and refactor CommandBus to use typed handlers
- ensure undo restores state when no undo handler and add unregister
- expand CommandBus tests for redo behavior and missing undo handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a24897ba083288b133c45d891856f