### PR TITLE
feat(core): add custom gesture FSM emitter

### DIFF
--- a/packages/core/src/vision/gestureFsm.ts
+++ b/packages/core/src/vision/gestureFsm.ts
@@ -1,5 +1,3 @@
-import { EventEmitter } from 'events';
-
 export type Gesture = 'idle' | 'draw' | 'palette' | 'fist';
 
 export interface HandInput {
@@ -7,19 +5,66 @@ export interface HandInput {
   fingers: number; // number of extended fingers
 }
 
-export class GestureFSM extends EventEmitter {
+export interface GestureFSMOptions {
+  drawPinch?: number;
+  drawMaxFingers?: number;
+  paletteFingers?: number;
+  fistFingers?: number;
+}
+
+type ChangeHandler = (g: Gesture) => void;
+
+export class GestureFSM {
   private state: Gesture = 'idle';
+  private readonly drawPinch: number;
+  private readonly drawMaxFingers: number;
+  private readonly paletteFingers: number;
+  private readonly fistFingers: number;
+  private listeners = new Set<ChangeHandler>();
+
+  constructor(opts: GestureFSMOptions = {}) {
+    const {
+      drawPinch = 0.8,
+      drawMaxFingers = 2,
+      paletteFingers = 5,
+      fistFingers = 0,
+    } = opts;
+    this.drawPinch = drawPinch;
+    this.drawMaxFingers = drawMaxFingers;
+    this.paletteFingers = paletteFingers;
+    this.fistFingers = fistFingers;
+  }
+
+  onChange(fn: ChangeHandler) {
+    this.listeners.add(fn);
+  }
+
+  offChange(fn: ChangeHandler) {
+    this.listeners.delete(fn);
+  }
+
+  private emit(next: Gesture) {
+    for (const fn of this.listeners) fn(next);
+  }
+
+  reset() {
+    if (this.state !== 'idle') {
+      this.state = 'idle';
+      this.emit(this.state);
+    }
+  }
 
   update(input: HandInput): Gesture {
     let next: Gesture = this.state;
-    if (input.pinch > 0.8 && input.fingers <= 2) next = 'draw';
-    else if (input.fingers === 5) next = 'palette';
-    else if (input.fingers === 0) next = 'fist';
+    if (input.pinch > this.drawPinch && input.fingers <= this.drawMaxFingers)
+      next = 'draw';
+    else if (input.fingers === this.paletteFingers) next = 'palette';
+    else if (input.fingers === this.fistFingers) next = 'fist';
     else next = 'idle';
 
     if (next !== this.state) {
       this.state = next;
-      this.emit('change', next);
+      this.emit(next);
     }
     return this.state;
   }

--- a/packages/core/test/gestureFsm.test.ts
+++ b/packages/core/test/gestureFsm.test.ts
@@ -7,4 +7,23 @@ describe('GestureFSM', () => {
     const g = fsm.update({ pinch: 0.9, fingers: 2 });
     expect(g).toBe('draw');
   });
+
+  it('uses custom thresholds', () => {
+    const fsm = new GestureFSM({ drawPinch: 0.5, drawMaxFingers: 3 });
+    const g = fsm.update({ pinch: 0.6, fingers: 3 });
+    expect(g).toBe('draw');
+  });
+
+  it('detaches change handler', () => {
+    const fsm = new GestureFSM();
+    let calls = 0;
+    const handler = () => {
+      calls++;
+    };
+    fsm.onChange(handler);
+    fsm.update({ pinch: 0.9, fingers: 2 });
+    fsm.offChange(handler);
+    fsm.reset();
+    expect(calls).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary
- replace Node's EventEmitter with lightweight custom emitter
- allow configuring gesture thresholds and expose reset API
- add onChange/offChange helpers with tests for thresholds and listener removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a248a7788832887130d76a4e0d766