### PR TITLE
feat: make palette configurable and accessible

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,6 @@
+# Supported Commands
+
+The following commands can be dispatched through the command bus and are used by the default radial palette:
+
+- `setColor` – expects an object with a `hex` field specifying the color.
+- `undo` – reverses the last action.

--- a/packages/web/src/components/RadialPalette.module.css
+++ b/packages/web/src/components/RadialPalette.module.css
@@ -1,0 +1,4 @@
+.radialPalette {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/packages/web/src/components/RadialPalette.tsx
+++ b/packages/web/src/components/RadialPalette.tsx
@@ -1,24 +1,55 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Command } from '@airdraw/core';
-
-interface PaletteItem { label: string; command: Command }
-const items: PaletteItem[] = [
-  { label: 'Black', command: { id: 'setColor', args: { hex: '#000000' } } },
-  { label: 'Red', command: { id: 'setColor', args: { hex: '#ff0000' } } },
-  { label: 'Undo', command: { id: 'undo', args: {} } }
-];
+import styles from './RadialPalette.module.css';
+import { PaletteItem, defaultPaletteItems } from '../config/palette';
 
 export interface RadialPaletteProps {
   visible: boolean;
   onSelect(cmd: Command): void;
+  items?: PaletteItem[];
 }
 
-export function RadialPalette({ visible, onSelect }: RadialPaletteProps) {
+export function RadialPalette({ visible, onSelect, items = defaultPaletteItems }: RadialPaletteProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const buttonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+
+  useEffect(() => {
+    if (visible) {
+      setActiveIndex(0);
+      buttonsRef.current[0]?.focus();
+    }
+  }, [visible]);
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      const next = (activeIndex + 1) % items.length;
+      setActiveIndex(next);
+      buttonsRef.current[next]?.focus();
+      e.preventDefault();
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      const prev = (activeIndex - 1 + items.length) % items.length;
+      setActiveIndex(prev);
+      buttonsRef.current[prev]?.focus();
+      e.preventDefault();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      onSelect(items[activeIndex].command);
+      e.preventDefault();
+    }
+  };
+
   if (!visible) return null;
   return (
-    <div className="radial-palette">
-      {items.map(it => (
-        <button key={it.label} onClick={() => onSelect(it.command)}>{it.label}</button>
+    <div className={styles.radialPalette} role="menu" aria-label="Command palette" onKeyDown={handleKeyDown}>
+      {items.map((it, idx) => (
+        <button
+          key={it.label}
+          ref={el => (buttonsRef.current[idx] = el)}
+          onClick={() => onSelect(it.command)}
+          role="menuitem"
+          tabIndex={idx === activeIndex ? 0 : -1}
+        >
+          {it.label}
+        </button>
       ))}
     </div>
   );

--- a/packages/web/src/config/palette.ts
+++ b/packages/web/src/config/palette.ts
@@ -1,0 +1,12 @@
+import { Command } from '@airdraw/core';
+
+export interface PaletteItem {
+  label: string;
+  command: Command;
+}
+
+export const defaultPaletteItems: PaletteItem[] = [
+  { label: 'Black', command: { id: 'setColor', args: { hex: '#000000' } } },
+  { label: 'Red', command: { id: 'setColor', args: { hex: '#ff0000' } } },
+  { label: 'Undo', command: { id: 'undo', args: {} } }
+];

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -4,6 +4,7 @@ import { useHandTracking } from './hooks/useHandTracking';
 import { RadialPalette } from './components/RadialPalette';
 import { CommandBus, Command } from '@airdraw/core';
 import { parsePrompt } from './ai/copilot';
+import { defaultPaletteItems } from './config/palette';
 
 const bus = new CommandBus();
 bus.register('setColor', async args => console.log('setColor', args));
@@ -21,7 +22,7 @@ function App() {
   return (
     <div>
       <video ref={videoRef} style={{ display: 'none' }} />
-      <RadialPalette visible={palette} onSelect={handleCommand} />
+      <RadialPalette visible={palette} onSelect={handleCommand} items={defaultPaletteItems} />
       <div>Gesture: {gesture}</div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow passing custom palette items and move defaults to a config module
- add keyboard navigation, ARIA roles and styling via CSS module
- document built-in commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a248c67f883288909870b35e188f4