### PR TITLE
feat: add grammar-based prompt parser with plan preview

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,8 +1,56 @@
 import { Command } from '@airdraw/core';
 
-export async function parsePrompt(prompt: string): Promise<Command[]> {
-  // Very small rule-based stub
-  if (/undo/i.test(prompt)) return [{ id: 'undo', args: {} }];
-  if (/red/i.test(prompt)) return [{ id: 'setColor', args: { hex: '#ff0000' } }];
-  return [];
+export interface PlanResult {
+  plan: string[];
+  commands: Command[];
+}
+
+const COLORS: Record<string, string> = {
+  red: '#ff0000',
+  blue: '#0000ff',
+  green: '#00ff00',
+};
+
+function describe(cmd: Command): string {
+  switch (cmd.id) {
+    case 'undo':
+      return 'Undo last action';
+    case 'setColor':
+      switch (cmd.args.hex) {
+        case '#ff0000':
+          return 'Set color to red';
+        case '#0000ff':
+          return 'Set color to blue';
+        case '#00ff00':
+          return 'Set color to green';
+        default:
+          return `Set color to ${cmd.args.hex}`;
+      }
+    default:
+      return cmd.id;
+  }
+}
+
+export async function parsePrompt(prompt: string): Promise<PlanResult> {
+  const segments = prompt
+    .split(/\s*(?:and|then|,)\s*/i)
+    .map(s => s.trim())
+    .filter(Boolean);
+
+  const commands: Command[] = [];
+  for (const seg of segments) {
+    if (/undo/i.test(seg)) {
+      commands.push({ id: 'undo', args: {} });
+      continue;
+    }
+
+    const colorMatch = seg.match(/\b(red|blue|green)\b/i);
+    if (colorMatch) {
+      const color = colorMatch[1].toLowerCase();
+      commands.push({ id: 'setColor', args: { hex: COLORS[color] } });
+    }
+  }
+
+  const plan = commands.map((cmd, idx) => `${idx + 1}. ${describe(cmd)}`);
+  return { plan, commands };
 }

--- a/packages/web/test/copilot.test.ts
+++ b/packages/web/test/copilot.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { parsePrompt } from '../src/ai/copilot';
+
+describe('parsePrompt', () => {
+  it('translates a single command', async () => {
+    const res = await parsePrompt('make it red');
+    expect(res.commands).toEqual([{ id: 'setColor', args: { hex: '#ff0000' } }]);
+    expect(res.plan).toEqual(['1. Set color to red']);
+  });
+
+  it('supports multi-command macros', async () => {
+    const res = await parsePrompt('make it red and undo');
+    expect(res.commands).toEqual([
+      { id: 'setColor', args: { hex: '#ff0000' } },
+      { id: 'undo', args: {} }
+    ]);
+    expect(res.plan).toEqual(['1. Set color to red', '2. Undo last action']);
+  });
+});


### PR DESCRIPTION
## Summary
- parse prompts using a small grammar that outputs deterministic plans and commands
- allow multiple commands per prompt for macro-style execution
- add tests covering prompt to command translation and plan generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a249040a48328b8d971e2d4ac008a