### PR TITLE
feat(core): add Catmull-Rom stroke smoothing

### DIFF
--- a/packages/core/src/draw/brushEngine.ts
+++ b/packages/core/src/draw/brushEngine.ts
@@ -1,4 +1,4 @@
-import { OneEuroFilter } from '../vision/oneEuro';
+import { OneEuroFilter, OneEuroConfig } from '../vision/oneEuro';
 
 export interface Vec2 { x: number; y: number }
 export interface BrushConfig { type: string; size: number; opacity: number; hardness: number }
@@ -9,15 +9,20 @@ export class BrushEngine {
   private filterX: OneEuroFilter;
   private filterY: OneEuroFilter;
   private current?: BrushConfig;
+  private baseCfg: OneEuroConfig;
 
-  constructor(filterCfg = { minCutoff: 1.0, beta: 0.0, dcutoff: 1.0 }) {
+  constructor(filterCfg: OneEuroConfig = { minCutoff: 1.0, beta: 0.0, dcutoff: 1.0 }) {
+    this.baseCfg = filterCfg;
     this.filterX = new OneEuroFilter(filterCfg);
     this.filterY = new OneEuroFilter(filterCfg);
   }
 
-  start(config: BrushConfig) {
+  start(config: BrushConfig, filterCfg?: OneEuroConfig) {
     this.current = config;
     this.points = [];
+    const cfg = filterCfg || this.baseCfg;
+    this.filterX = new OneEuroFilter(cfg);
+    this.filterY = new OneEuroFilter(cfg);
   }
 
   addPoint(p: Vec2, t: number) {
@@ -26,9 +31,41 @@ export class BrushEngine {
     this.points.push({ x, y });
   }
 
+  private fitCatmull(points: Vec2[], segments = 8): Vec2[] {
+    if (points.length < 2) return points.slice();
+    const res: Vec2[] = [];
+    for (let i = 0; i < points.length - 1; i++) {
+      const p0 = points[i - 1] || points[i];
+      const p1 = points[i];
+      const p2 = points[i + 1];
+      const p3 = points[i + 2] || p2;
+      for (let j = 0; j < segments; j++) {
+        const t = j / segments;
+        const t2 = t * t;
+        const t3 = t2 * t;
+        const x =
+          0.5 *
+          ((2 * p1.x) +
+            (-p0.x + p2.x) * t +
+            (2 * p0.x - 5 * p1.x + 4 * p2.x - p3.x) * t2 +
+            (-p0.x + 3 * p1.x - 3 * p2.x + p3.x) * t3);
+        const y =
+          0.5 *
+          ((2 * p1.y) +
+            (-p0.y + p2.y) * t +
+            (2 * p0.y - 5 * p1.y + 4 * p2.y - p3.y) * t2 +
+            (-p0.y + 3 * p1.y - 3 * p2.y + p3.y) * t3);
+        res.push({ x, y });
+      }
+    }
+    res.push(points[points.length - 1]);
+    return res;
+  }
+
   end(): BrushStroke {
     if (!this.current) throw new Error('brush not started');
-    const stroke = { points: this.points, brush: this.current };
+    const fitted = this.fitCatmull(this.points);
+    const stroke = { points: fitted, brush: this.current };
     this.current = undefined;
     this.points = [];
     return stroke;

--- a/packages/core/test/brushEngine.test.ts
+++ b/packages/core/test/brushEngine.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { BrushEngine } from '../src/draw/brushEngine';
+
+const baseConfig = { type: 'pen', size: 1, opacity: 1, hardness: 1 };
+
+describe('BrushEngine', () => {
+  it('applies smoothing via OneEuro filter', () => {
+    const engine = new BrushEngine();
+    engine.start(baseConfig);
+    let t = 0;
+    engine.addPoint({ x: 0, y: 0 }, (t += 16));
+    engine.addPoint({ x: 10, y: 10 }, (t += 16));
+    const pts = (engine as any).points as { x: number; y: number }[];
+    expect(pts[1].x).toBeLessThan(10);
+  });
+
+  it('returns Catmull-Rom interpolated stroke', () => {
+    const engine = new BrushEngine();
+    engine.start(baseConfig, { minCutoff: 1e6, beta: 0, dcutoff: 1e6 });
+    let t = 0;
+    const raw = [
+      { x: 0, y: 0 },
+      { x: 1, y: 1 },
+      { x: 2, y: 0 }
+    ];
+    for (const p of raw) engine.addPoint(p, (t += 16));
+    const stroke = engine.end();
+    const expected = [
+      { x: 0, y: 0 },
+      { x: 0.0771484375, y: 0.0908203125 },
+      { x: 0.1796875, y: 0.2265625 },
+      { x: 0.3017578125, y: 0.3896484375 },
+      { x: 0.4375, y: 0.5625 },
+      { x: 0.5810546875, y: 0.7275390625 },
+      { x: 0.7265625, y: 0.8671875 },
+      { x: 0.8681640625, y: 0.9638671875 },
+      { x: 1, y: 1 },
+      { x: 1.1318359375, y: 0.9638671875 },
+      { x: 1.2734375, y: 0.8671875 },
+      { x: 1.4189453125, y: 0.7275390625 },
+      { x: 1.5625, y: 0.5625 },
+      { x: 1.6982421875, y: 0.3896484375 },
+      { x: 1.8203125, y: 0.2265625 },
+      { x: 1.9228515625, y: 0.0908203125 },
+      { x: 2, y: 0 }
+    ];
+    expect(stroke.points.length).toBe(expected.length);
+    expected.forEach((p, i) => {
+      expect(stroke.points[i].x).toBeCloseTo(p.x, 6);
+      expect(stroke.points[i].y).toBeCloseTo(p.y, 6);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- interpolate brush strokes with Catmull-Rom splines before commit
- allow BrushEngine.start to override One-Euro filter parameters per stroke
- add tests for smoothing and spline output

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a248d8be883289e3b263f15e57881