### PR TITLE
feat(core): implement command bus with undo/redo stacks

### DIFF
--- a/packages/core/src/commands/commandBus.ts
+++ b/packages/core/src/commands/commandBus.ts
@@ -1,11 +1,50 @@
+export type CommandHandler<Args> = (args: Args) => void | Promise<void>;
 
+export type Command<ID extends string, Args> = {
+  id: ID;
+  args: Args;
+};
+
+export class CommandBus<Cmds extends Record<string, any>> {
+  private handlers = new Map<string, CommandHandler<any>>();
+  private undoStack: Array<Command<keyof Cmds & string, any>> = [];
+  private redoStack: Array<Command<keyof Cmds & string, any>> = [];
+
+  register<ID extends string, Args>(id: ID, handler: CommandHandler<Args>) {
+    this.handlers.set(id, handler as CommandHandler<any>);
+  }
+
+  async dispatch<ID extends keyof Cmds>(cmd: Command<ID & string, Cmds[ID]>) {
+    const handler = this.handlers.get(cmd.id as string);
+    if (!handler) return;
     await handler(cmd.args);
-    this.undoStack.push(cmd);
+    this.undoStack.push(cmd as Command<keyof Cmds & string, any>);
     this.redoStack = [];
   }
 
-
+  async undo() {
     const cmd = this.undoStack.pop();
     if (!cmd) return;
+    const handler = this.handlers.get(`undo:${String(cmd.id)}`);
+    if (!handler) {
+      // Restore state when there is no inverse handler
+      this.undoStack.push(cmd);
+      return;
+    }
+    await handler(cmd.args);
+    this.redoStack.push(cmd);
+  }
 
+  async redo() {
+    const cmd = this.redoStack.pop();
+    if (!cmd) return;
+    const handler = this.handlers.get(String(cmd.id));
+    if (!handler) {
+      // Restore state if redo handler is missing
+      this.redoStack.push(cmd);
+      return;
+    }
+    await handler(cmd.args);
+    this.undoStack.push(cmd);
+  }
 }

--- a/packages/core/test/commandBus.test.ts
+++ b/packages/core/test/commandBus.test.ts
@@ -1,30 +1,44 @@
 import { describe, it, expect } from 'vitest';
+import { CommandBus } from '../src/commands';
 
+describe('CommandBus', () => {
+  it('dispatches and undoes commands', async () => {
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
     let count = 0;
-    bus.register('inc', async () => { await Promise.resolve(); count++; });
-    bus.register('undo:inc', async () => { await Promise.resolve(); count--; });
+    bus.register('inc', async () => {
+      await Promise.resolve();
+      count++;
+    });
+    bus.register('undo:inc', async () => {
+      await Promise.resolve();
+      count--;
+    });
     await bus.dispatch({ id: 'inc', args: {} });
     expect(count).toBe(1);
     await bus.undo();
     expect(count).toBe(0);
     await bus.redo();
     expect(count).toBe(1);
-
   });
 
   it('redos commands without losing handlers', async () => {
     type Cmds = { inc: {} };
     const bus = new CommandBus<Cmds>();
     let count = 0;
-    bus.register('inc', () => { count++; });
-    bus.register('undo:inc', () => { count--; });
+    bus.register('inc', () => {
+      count++;
+    });
+    bus.register('undo:inc', () => {
+      count--;
+    });
     await bus.dispatch({ id: 'inc', args: {} });
     expect(count).toBe(1);
-    bus.undo();
+    await bus.undo();
     expect(count).toBe(0);
     await bus.redo();
     expect(count).toBe(1);
-    bus.undo();
+    await bus.undo();
     expect(count).toBe(0);
   });
 
@@ -32,10 +46,12 @@ import { describe, it, expect } from 'vitest';
     type Cmds = { inc: {} };
     const bus = new CommandBus<Cmds>();
     let count = 0;
-    bus.register('inc', () => { count++; });
+    bus.register('inc', () => {
+      count++;
+    });
     await bus.dispatch({ id: 'inc', args: {} });
     expect(count).toBe(1);
-    bus.undo();
+    await bus.undo();
     expect(count).toBe(1);
     await bus.redo();
     expect(count).toBe(1);


### PR DESCRIPTION
## Summary
- implement full CommandBus with handler registration and undo/redo stacks
- add tests for dispatch, redo persistence, and missing undo handler

## Testing
- `npx vitest run packages/core/test/commandBus.test.ts`
- `npm test` *(fails: Transform failed with errors and missing jsdom)*

------
https://chatgpt.com/codex/tasks/task_e_689ad46fafb48328ae298538f862f830