### PR TITLE
feat: add radial palette component

### DIFF
--- a/packages/web/src/components/RadialPalette.tsx
+++ b/packages/web/src/components/RadialPalette.tsx
@@ -1,6 +1,39 @@
+import React from 'react';
+import styles from './RadialPalette.module.css';
+import { defaultPaletteItems, PaletteItem } from '../config/palette';
+import { Command } from '@airdraw/core';
 
+export interface RadialPaletteProps {
+  onSelect?: (command: Command) => void;
+}
 
+export function RadialPalette({ onSelect }: RadialPaletteProps) {
+  const handleSelect = (item: PaletteItem) => {
+    onSelect?.(item.command);
+  };
+
+  const handleKeyDown = (item: PaletteItem, e: React.KeyboardEvent<HTMLButtonElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      handleSelect(item);
+    }
+  };
+
+  return (
+    <ul className={styles.radialPalette}>
+      {defaultPaletteItems.map(item => (
+        <li key={item.label}>
+          <button
+            type="button"
+            onClick={() => handleSelect(item)}
+            onKeyDown={e => handleKeyDown(item, e)}
+          >
+            {item.label}
+          </button>
+        </li>
       ))}
     </ul>
   );
 }
+
+export default RadialPalette;

--- a/packages/web/test/RadialPalette.test.tsx
+++ b/packages/web/test/RadialPalette.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { RadialPalette } from '../src/components/RadialPalette';
+import { defaultPaletteItems } from '../src/config/palette';
+
+describe('RadialPalette', () => {
+  it('renders palette items and handles selection', () => {
+    const onSelect = vi.fn();
+    render(<RadialPalette onSelect={onSelect} />);
+
+    // Renders items
+    defaultPaletteItems.forEach(item => {
+      expect(screen.getByText(item.label)).toBeTruthy();
+    });
+
+    // Click selection
+    fireEvent.click(screen.getByText(defaultPaletteItems[1].label));
+    expect(onSelect).toHaveBeenNthCalledWith(1, defaultPaletteItems[1].command);
+
+    // Keyboard selection
+    const firstButton = screen.getByText(defaultPaletteItems[0].label);
+    fireEvent.keyDown(firstButton, { key: 'Enter' });
+    expect(onSelect).toHaveBeenNthCalledWith(2, defaultPaletteItems[0].command);
+  });
+});


### PR DESCRIPTION
## Summary
- implement RadialPalette component to render default palette with accessible buttons
- add tests for RadialPalette render and selection

## Testing
- `npx vitest run packages/web/test/RadialPalette.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689ad47186c88328963e7d0849781144