### PR TITLE
feat(web): rewrite app entry with hand tracking

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,8 +1,33 @@
 import { AppCommand } from '../commands';
 
+export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
+  const key = process.env.OPENAI_API_KEY;
+  if (key) {
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${key}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-3.5-turbo',
+          messages: [{ role: 'user', content: prompt }],
+        }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const text = data.choices?.[0]?.message?.content;
+        if (text) {
+          return JSON.parse(text) as AppCommand[];
+        }
+      }
+    } catch {
+      // fall through to rule-based parser
+    }
+  }
 
   if (/undo/i.test(prompt)) return [{ id: 'undo', args: {} }];
   if (/red/i.test(prompt)) return [{ id: 'setColor', args: { hex: '#ff0000' } }];
   return [];
 }
-

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,31 +1,42 @@
-import React, { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { CommandBus, type AppCommand } from '@airdraw/core';
 import { useHandTracking } from './hooks/useHandTracking';
-
+import { RadialPalette } from './components/RadialPalette';
 import { parsePrompt } from './ai/copilot';
 
+export const bus = new CommandBus<AppCommand>();
 
 bus.register('setColor', async args => console.log('setColor', args));
 bus.register('undo', () => console.log('undo'));
 
-
-  const [palette, setPalette] = useState(false);
+export function App() {
+  const { videoRef, gesture } = useHandTracking();
   const [prompt, setPrompt] = useState('');
-
 
   const handleCommand = (cmd: AppCommand) => {
     bus.dispatch(cmd);
-    setPalette(false);
   };
 
-
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const cmds = await parsePrompt(prompt);
+    cmds.forEach(handleCommand);
+    setPrompt('');
+  };
 
   return (
     <div>
-      <video ref={videoRef} style={{ display: 'none' }} />
-
+      <video ref={videoRef} hidden />
       <div>Gesture: {gesture}</div>
-
+      {gesture === 'palette' && <RadialPalette onSelect={handleCommand} />}
+      <form onSubmit={handleSubmit}>
+        <input
+          placeholder="prompt"
+          value={prompt}
+          onChange={e => setPrompt(e.target.value)}
+        />
+      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- rewrite web app entry with App component and command bus
- add fallback LLM prompt parsing for commands

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689aed6e697483289d3a2b45d189ab82