### PR TITLE
feat: expose CommandOf utility type

### DIFF
--- a/packages/core/src/commands/commandBus.ts
+++ b/packages/core/src/commands/commandBus.ts
@@ -5,6 +5,10 @@ export type Command<ID extends string, Args> = {
   args: Args;
 };
 
+export type CommandOf<M extends Record<string, any>> = {
+  [K in keyof M]: { id: K; args: M[K] };
+}[keyof M];
+
 export class CommandBus<Cmds extends Record<string, any>> {
   private handlers = new Map<string, CommandHandler<any>>();
   private undoStack: Array<Command<keyof Cmds & string, any>> = [];

--- a/packages/core/src/commands/index.ts
+++ b/packages/core/src/commands/index.ts
@@ -1,1 +1,2 @@
-export * from './commandBus';
+export { CommandBus } from './commandBus';
+export type { Command, CommandHandler, CommandOf } from './commandBus';

--- a/packages/core/test/commandOf.test.ts
+++ b/packages/core/test/commandOf.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import { CommandOf } from '../src/commands';
+
+describe('CommandOf', () => {
+  it('infers union of command objects from map', () => {
+    type CmdMap = {
+      setColor: { hex: string };
+      undo: {};
+    };
+
+    expectTypeOf<CommandOf<CmdMap>>().toEqualTypeOf<
+      | { id: 'setColor'; args: { hex: string } }
+      | { id: 'undo'; args: {} }
+    >();
+  });
+});


### PR DESCRIPTION
## Summary
- add `CommandOf` helper type for typed command maps
- export new `CommandOf` type from core commands module
- test `CommandOf` type inference

## Testing
- `npx tsc packages/web/src/commands.ts --noEmit`
- `npm test` *(fails: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_689aed72a15483289334510989ffbbb1