### PR TITLE
test: mock core package in handtracking test

### DIFF
--- a/packages/web/test/useHandTracking.test.ts
+++ b/packages/web/test/useHandTracking.test.ts
@@ -2,10 +2,13 @@ import React from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
-import { GestureFSM } from '../../core/src/vision/gestureFsm';
+import { GestureFSM } from '@airdraw/core';
 
 vi.mock('@mediapipe/hands', () => ({ Hands: vi.fn() }));
-vi.mock('@airdraw/core', () => ({ GestureFSM }));
+vi.mock('@airdraw/core', async () => {
+  const actual = await vi.importActual<typeof import('@airdraw/core')>('@airdraw/core');
+  return { GestureFSM: actual.GestureFSM };
+});
 
 import { Hands } from '@mediapipe/hands';
 const HandsMock = Hands as unknown as any;


### PR DESCRIPTION
## Summary
- adjust useHandTracking test to import GestureFSM from @airdraw/core
- stub @airdraw/core via vi.importActual for testing

## Testing
- `npm test packages/web/test/useHandTracking.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689aed7438bc83289f82d0383cedae89