### PR TITLE
feat(web): wire up hand tracking app

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,7 +1,15 @@
-import { AppCommand } from '../commands';
+import type { AppCommand } from '../commands';
 
-
+export function parsePrompt(prompt: string): AppCommand[] {
+  const p = prompt.toLowerCase();
+  if (p.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
   }
-
+  if (p.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+  if (p.includes('black')) {
+    return [{ id: 'setColor', args: { hex: '#000000' } }];
+  }
   return [];
 }


### PR DESCRIPTION
## Summary
- implement App component using hand tracking and command bus
- add basic prompt parser for undo and color commands

## Testing
- `npx vitest run packages/web/test/app.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_689b0e294b788328a64df39203ca8b9a