### PR TITLE
feat: implement copilot prompt parser

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,6 +1,21 @@
 import { AppCommand } from '../commands';
 
+/**
+ * Parse a natural language prompt into application commands.
+ */
+export function parsePrompt(text: string): AppCommand[] {
+  const normalized = text.toLowerCase();
 
+  if (normalized.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
+  }
+
+  if (normalized.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+
+  if (normalized.includes('black')) {
+    return [{ id: 'setColor', args: { hex: '#000000' } }];
   }
 
   return [];


### PR DESCRIPTION
## Summary
- implement `parsePrompt` to convert undo/black/red prompts into `AppCommand`s

## Testing
- `npm test` *(fails: Unexpected `}` in `packages/web/src/main.tsx`)*

------
https://chatgpt.com/codex/tasks/task_e_689b0e2acf448328a75fff5557581593