### PR TITLE
feat(core): add undo handler support to CommandBus

### DIFF
--- a/packages/core/test/commandBus.test.ts
+++ b/packages/core/test/commandBus.test.ts
@@ -6,14 +6,17 @@ describe('CommandBus', () => {
     type Cmds = { inc: {} };
     const bus = new CommandBus<Cmds>();
     let count = 0;
-    bus.register('inc', async () => {
-      await Promise.resolve();
-      count++;
-    });
-    bus.register('undo:inc', async () => {
-      await Promise.resolve();
-      count--;
-    });
+    bus.register(
+      'inc',
+      async () => {
+        await Promise.resolve();
+        count++;
+      },
+      async () => {
+        await Promise.resolve();
+        count--;
+      }
+    );
     await bus.dispatch({ id: 'inc', args: {} });
     expect(count).toBe(1);
     await bus.undo();
@@ -26,12 +29,15 @@ describe('CommandBus', () => {
     type Cmds = { inc: {} };
     const bus = new CommandBus<Cmds>();
     let count = 0;
-    bus.register('inc', () => {
-      count++;
-    });
-    bus.register('undo:inc', () => {
-      count--;
-    });
+    bus.register(
+      'inc',
+      () => {
+        count++;
+      },
+      () => {
+        count--;
+      }
+    );
     await bus.dispatch({ id: 'inc', args: {} });
     expect(count).toBe(1);
     await bus.undo();


### PR DESCRIPTION
## Summary
- extend CommandBus to store paired do/undo handlers without string prefixes
- support optional undo handler in `register` and use paired handlers for dispatch/undo/redo
- update command bus tests to register undo handlers via the new API

## Testing
- `npx vitest run packages/core/test/commandBus.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b0e2c59548328b30f5935d9df72a8