### PR TITLE
feat(web): surface hand tracking errors

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,4 +1,15 @@
+import type { AppCommand } from '../commands';
 
+// Naive prompt parser used for testing.
+export function parsePrompt(prompt: string): AppCommand[] {
+  const text = prompt.toLowerCase();
+  if (text.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
+  }
+  if (text.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+  if (text.includes('black')) {
     return [{ id: 'setColor', args: { hex: '#000000' } }];
   }
   return [];

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
-
-
-export const bus = new CommandBus<AppCommands>();
+import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
+import { parsePrompt } from './ai/copilot';
+import { useHandTracking } from './hooks/useHandTracking';
+import RadialPalette from './components/RadialPalette';
 
 export function App() {
-  const { videoRef, gesture } = useHandTracking();
+  const { videoRef, gesture, error } = useHandTracking();
+  const bus = useCommandBus();
   const [prompt, setPrompt] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -17,12 +19,13 @@ export function App() {
     setPrompt('');
   };
 
-
-  };
+  const handlePaletteSelect = (cmd: any) => bus.dispatch(cmd);
 
   return (
     <div>
       <video ref={videoRef} hidden />
+      {error && <p role="alert">{error.message}</p>}
+      {gesture === 'palette' && <RadialPalette onSelect={handlePaletteSelect} />}
       <form onSubmit={handleSubmit}>
         <input
           placeholder="prompt"
@@ -30,7 +33,6 @@ export function App() {
           onChange={e => setPrompt(e.target.value)}
         />
       </form>
-
     </div>
   );
 }

--- a/packages/web/test/app.test.tsx
+++ b/packages/web/test/app.test.tsx
@@ -10,8 +10,9 @@ import type { AppCommands } from '../src/commands';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 
 let mockGesture: string = 'idle';
+let mockError: Error | null = null;
 vi.mock('../src/hooks/useHandTracking', () => ({
-  useHandTracking: () => ({ videoRef: { current: null }, gesture: mockGesture })
+  useHandTracking: () => ({ videoRef: { current: null }, gesture: mockGesture, error: mockError })
 }));
 
 vi.mock('../src/ai/copilot', () => ({
@@ -24,6 +25,7 @@ describe('App', () => {
     cleanup();
     vi.clearAllMocks();
     mockGesture = 'idle';
+    mockError = null;
   });
     it('shows palette only when gesture is palette', () => {
       const bus = new CommandBus<AppCommands>();
@@ -57,5 +59,16 @@ describe('App', () => {
       await waitFor(() => {
         expect(dispatchSpy).toHaveBeenCalledWith({ id: 'undo', args: {} });
       });
+    });
+
+    it('renders error from hand tracking', () => {
+      const bus = new CommandBus<AppCommands>();
+      mockError = new Error('camera denied');
+      render(
+        <CommandBusProvider bus={bus}>
+          <App />
+        </CommandBusProvider>
+      );
+      expect(screen.getByRole('alert').textContent).toContain('camera denied');
     });
 });


### PR DESCRIPTION
## Summary
- show a visible error message when `useHandTracking` reports a failure
- add regression test for the hand-tracking error UI
- implement simple prompt parser for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8be7bac483288188850c123df2e7