### PR TITLE
Add CommandBus context test and fix web app wiring

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,4 +1,14 @@
+import { AppCommand } from '../commands';
 
+export function parsePrompt(prompt: string): AppCommand[] {
+  const p = prompt.toLowerCase();
+  if (p.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
+  }
+  if (p.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+  if (p.includes('black')) {
     return [{ id: 'setColor', args: { hex: '#000000' } }];
   }
   return [];

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,28 +1,34 @@
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
-
+import { CommandBus } from '@airdraw/core';
+import type { AppCommands, AppCommand } from './commands';
+import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
+import { useHandTracking } from './hooks/useHandTracking';
+import { RadialPalette } from './components/RadialPalette';
+import { parsePrompt } from './ai/copilot';
 
 export const bus = new CommandBus<AppCommands>();
 
 export function App() {
   const { videoRef, gesture } = useHandTracking();
+  const bus = useCommandBus();
   const [prompt, setPrompt] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const cmds = await parsePrompt(prompt);
+    const cmds: AppCommand[] = await parsePrompt(prompt);
     for (const cmd of cmds) {
       bus.dispatch(cmd);
     }
     setPrompt('');
   };
 
-
-  };
-
   return (
     <div>
       <video ref={videoRef} hidden />
+      {gesture === 'palette' && (
+        <RadialPalette onSelect={cmd => bus.dispatch(cmd)} />
+      )}
       <form onSubmit={handleSubmit}>
         <input
           placeholder="prompt"
@@ -30,7 +36,6 @@ export function App() {
           onChange={e => setPrompt(e.target.value)}
         />
       </form>
-
     </div>
   );
 }

--- a/packages/web/test/CommandBusContext.test.tsx
+++ b/packages/web/test/CommandBusContext.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { CommandBus } from '@airdraw/core';
+import type { AppCommands } from '../src/commands';
+import { CommandBusProvider, useCommandBus } from '../src/context/CommandBusContext';
+
+describe('CommandBusContext', () => {
+  it('provides the given bus and dispatches commands', async () => {
+    const bus = new CommandBus<AppCommands>();
+    const dispatchSpy = vi.spyOn(bus, 'dispatch');
+    let hookBus: CommandBus<AppCommands> | null = null;
+
+    function TestComponent() {
+      const b = useCommandBus();
+      hookBus = b;
+      React.useEffect(() => {
+        b.dispatch({ id: 'undo', args: {} });
+      }, [b]);
+      return null;
+    }
+
+    render(
+      <CommandBusProvider bus={bus}>
+        <TestComponent />
+      </CommandBusProvider>
+    );
+
+    expect(hookBus).toBe(bus);
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith({ id: 'undo', args: {} });
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- test CommandBusProvider and useCommandBus interaction
- implement minimal parsePrompt and App wiring for tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b8be84b9c8328950d6a5d0bba4860