### PR TITLE
feat: implement copilot prompt parser

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,5 +1,26 @@
+import type { AppCommand } from '../commands';
 
+/**
+ * Parse a natural language prompt into application commands.
+ *
+ * @param text Prompt provided by the user.
+ * @returns A list of commands inferred from the prompt.
+ */
+export async function parsePrompt(text: string): Promise<AppCommand[]> {
+  const normalized = text.toLowerCase();
+
+  if (normalized.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
+  }
+
+  if (normalized.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+
+  if (normalized.includes('black')) {
     return [{ id: 'setColor', args: { hex: '#000000' } }];
   }
+
   return [];
 }
+

--- a/packages/web/test/copilot.test.ts
+++ b/packages/web/test/copilot.test.ts
@@ -2,26 +2,26 @@ import { describe, it, expect } from 'vitest';
 import { parsePrompt } from '../src/ai/copilot';
 
 describe('parsePrompt', () => {
-  it('handles undo intent', () => {
-    expect(parsePrompt('undo the last action')).toEqual([
+  it('handles undo intent', async () => {
+    expect(await parsePrompt('undo the last action')).toEqual([
       { id: 'undo', args: {} },
     ]);
   });
 
-  it('handles red intent', () => {
-    expect(parsePrompt('make it red')).toEqual([
+  it('handles red intent', async () => {
+    expect(await parsePrompt('make it red')).toEqual([
       { id: 'setColor', args: { hex: '#ff0000' } },
     ]);
   });
 
-  it('handles black intent', () => {
-    expect(parsePrompt('switch to black')).toEqual([
+  it('handles black intent', async () => {
+    expect(await parsePrompt('switch to black')).toEqual([
       { id: 'setColor', args: { hex: '#000000' } },
     ]);
   });
 
-  it('returns empty array for unknown prompts', () => {
-    expect(parsePrompt('do something else')).toEqual([]);
+  it('returns empty array for unknown prompts', async () => {
+    expect(await parsePrompt('do something else')).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary
- add async parsePrompt that maps undo, red, and black keywords to app commands
- update copilot tests to await async parsePrompt

## Testing
- `npm test packages/web/test/copilot.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_689b8be6aee08328b97109483f33189b