### PR TITLE
feat(web): add app component

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,7 +1,18 @@
+import type { AppCommand } from '../commands';
 
+export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
+  const text = prompt.toLowerCase();
+  if (text.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
+  }
+  if (text.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+  if (text.includes('black')) {
     return [{ id: 'setColor', args: { hex: '#000000' } }];
   }
-
   return [];
 }
+
+export default { parsePrompt };
 

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,8 +1,15 @@
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { useHandTracking } from './hooks/useHandTracking';
+import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
+import { RadialPalette } from './components/RadialPalette';
+import { parsePrompt } from './ai/copilot';
+import type { AppCommand } from './commands';
 
-  const [prompt, setPrompt] = useState('');
+export function App() {
+  const { videoRef, gesture, error } = useHandTracking();
   const bus = useCommandBus();
+  const [prompt, setPrompt] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -13,7 +20,19 @@ import { createRoot } from 'react-dom/client';
     setPrompt('');
   };
 
+  const handlePaletteSelect = (cmd: AppCommand) => {
+    bus.dispatch(cmd);
+  };
 
+  return (
+    <div>
+      <video ref={videoRef} style={{ display: 'none' }} />
+      {gesture === 'palette' && <RadialPalette onSelect={handlePaletteSelect} />}
+      {error && (
+        <div role="alert">
+          {error.message}
+        </div>
+      )}
       <form onSubmit={handleSubmit}>
         <input
           placeholder="prompt"
@@ -33,3 +52,6 @@ if (el) {
     </CommandBusProvider>
   );
 }
+
+export default App;
+


### PR DESCRIPTION
## Summary
- implement App component with hand tracking, prompt parsing, and radial palette
- add simple prompt parser for undo and color commands

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689be7ac51548328b2a282e7ef31640f