### PR TITLE
feat: add drawing canvas with undo and color

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,7 +1,15 @@
+import type { AppCommand } from '../commands';
 
+export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
+  const p = prompt.toLowerCase();
+  if (p.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
+  }
+  if (p.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+  if (p.includes('black')) {
     return [{ id: 'setColor', args: { hex: '#000000' } }];
   }
-
   return [];
 }
-

--- a/packages/web/src/components/DrawingCanvas.tsx
+++ b/packages/web/src/components/DrawingCanvas.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useRef } from 'react';
+import { BrushEngine, type Vec2 } from '@airdraw/core';
+
+export interface Stroke {
+  points: Vec2[];
+  color: string;
+}
+
+export interface DrawingCanvasProps {
+  gesture: string;
+  color: string;
+  strokes: Stroke[];
+  onStrokeComplete: (stroke: Stroke) => void;
+}
+
+export function DrawingCanvas({ gesture, color, strokes, onStrokeComplete }: DrawingCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const engineRef = useRef(new BrushEngine());
+  const drawingRef = useRef(false);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    let ctx: CanvasRenderingContext2D | null = null;
+    try {
+      ctx = canvas.getContext('2d');
+    } catch {
+      ctx = null;
+    }
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (const stroke of strokes) {
+      const pts = stroke.points;
+      if (pts.length === 0) continue;
+      ctx.strokeStyle = stroke.color;
+      ctx.lineWidth = 4;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(pts[0].x, pts[0].y);
+      for (let i = 1; i < pts.length; i++) {
+        ctx.lineTo(pts[i].x, pts[i].y);
+      }
+      ctx.stroke();
+    }
+  }, [strokes]);
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (gesture !== 'draw') return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = typeof e.clientX === 'number' ? e.clientX - rect.left : 0;
+    const y = typeof e.clientY === 'number' ? e.clientY - rect.top : 0;
+    const p = { x, y };
+    engineRef.current.start({ type: 'basic', size: 4, opacity: 1, hardness: 1 });
+    engineRef.current.addPoint(p, e.timeStamp);
+    drawingRef.current = true;
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!drawingRef.current || gesture !== 'draw') return;
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = typeof e.clientX === 'number' ? e.clientX - rect.left : 0;
+    const y = typeof e.clientY === 'number' ? e.clientY - rect.top : 0;
+    const p = { x, y };
+    engineRef.current.addPoint(p, e.timeStamp);
+  };
+
+  const endStroke = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!drawingRef.current) return;
+    const stroke = engineRef.current.end();
+    drawingRef.current = false;
+    onStrokeComplete({ color, points: stroke.points });
+  };
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={500}
+      height={500}
+      data-testid="drawing-canvas"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endStroke}
+      onPointerLeave={endStroke}
+    />
+  );
+}
+
+export default DrawingCanvas;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,19 +1,48 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
+import { useHandTracking } from './hooks/useHandTracking';
+import RadialPalette from './components/RadialPalette';
+import DrawingCanvas, { type Stroke } from './components/DrawingCanvas';
+import type { AppCommand } from './commands';
+import { parsePrompt } from './ai/copilot';
 
-  const [prompt, setPrompt] = useState('');
+export function App() {
+  const { videoRef, gesture, error } = useHandTracking();
   const bus = useCommandBus();
+  const [prompt, setPrompt] = useState('');
+  const [color, setColor] = useState('#000000');
+  const [strokes, setStrokes] = useState<Stroke[]>([]);
+
+  useEffect(() => {
+    bus.register('setColor', ({ hex }) => setColor(hex));
+    bus.register('undo', () => setStrokes(s => s.slice(0, -1)));
+  }, [bus]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const cmds: AppCommand[] = await parsePrompt(prompt);
     for (const cmd of cmds) {
-      bus.dispatch(cmd);
+      await bus.dispatch(cmd);
     }
     setPrompt('');
   };
 
+  const handlePaletteSelect = (cmd: any) => {
+    bus.dispatch(cmd as AppCommand);
+  };
 
+  return (
+    <div>
+      {error && <div role="alert">{error.message}</div>}
+      <video ref={videoRef} />
+      <DrawingCanvas
+        gesture={gesture}
+        color={color}
+        strokes={strokes}
+        onStrokeComplete={s => setStrokes(strokes => [...strokes, s])}
+      />
+      {gesture === 'palette' && <RadialPalette onSelect={handlePaletteSelect} />}
       <form onSubmit={handleSubmit}>
         <input
           placeholder="prompt"
@@ -21,6 +50,7 @@ import { createRoot } from 'react-dom/client';
           onChange={e => setPrompt(e.target.value)}
         />
       </form>
+      <pre data-testid="strokes">{JSON.stringify(strokes)}</pre>
     </div>
   );
 }

--- a/packages/web/test/drawingCanvas.test.tsx
+++ b/packages/web/test/drawingCanvas.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, fireEvent, screen, waitFor, cleanup } from '@testing-library/react';
+import { CommandBus } from '@airdraw/core';
+import { CommandBusProvider } from '../src/context/CommandBusContext';
+import type { AppCommands } from '../src/commands';
+import { App } from '../src/main';
+import { afterEach, describe, it, vi, expect } from 'vitest';
+
+let mockGesture = 'draw';
+
+vi.mock('../src/hooks/useHandTracking', () => ({
+  useHandTracking: () => ({ videoRef: { current: null }, gesture: mockGesture, error: null })
+}));
+
+describe('DrawingCanvas integration', () => {
+  afterEach(() => {
+    cleanup();
+    mockGesture = 'draw';
+  });
+
+  it('applies color changes to new strokes', async () => {
+    const bus = new CommandBus<AppCommands>();
+    render(
+      <CommandBusProvider bus={bus}>
+        <App />
+      </CommandBusProvider>
+    );
+    const canvas = screen.getByTestId('drawing-canvas');
+
+    fireEvent.pointerDown(canvas, { clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(canvas, { clientX: 20, clientY: 20 });
+    fireEvent.pointerUp(canvas, { clientX: 20, clientY: 20 });
+
+    await waitFor(() => {
+      const strokes = JSON.parse(screen.getByTestId('strokes').textContent!);
+      expect(strokes.length).toBe(1);
+      expect(strokes[0].color).toBe('#000000');
+    });
+
+    await bus.dispatch({ id: 'setColor', args: { hex: '#ff0000' } });
+
+    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.pointerMove(canvas, { clientX: 40, clientY: 40 });
+    fireEvent.pointerUp(canvas, { clientX: 40, clientY: 40 });
+
+    await waitFor(() => {
+      const strokes = JSON.parse(screen.getByTestId('strokes').textContent!);
+      expect(strokes.length).toBe(2);
+      expect(strokes[1].color).toBe('#ff0000');
+    });
+  });
+
+  it('removes the last stroke on undo command', async () => {
+    const bus = new CommandBus<AppCommands>();
+    render(
+      <CommandBusProvider bus={bus}>
+        <App />
+      </CommandBusProvider>
+    );
+    const canvas = screen.getByTestId('drawing-canvas');
+
+    fireEvent.pointerDown(canvas, { clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(canvas, { clientX: 20, clientY: 20 });
+    fireEvent.pointerUp(canvas, { clientX: 20, clientY: 20 });
+
+    fireEvent.pointerDown(canvas, { clientX: 30, clientY: 30 });
+    fireEvent.pointerMove(canvas, { clientX: 40, clientY: 40 });
+    fireEvent.pointerUp(canvas, { clientX: 40, clientY: 40 });
+
+    await waitFor(() => {
+      const strokes = JSON.parse(screen.getByTestId('strokes').textContent!);
+      expect(strokes.length).toBe(2);
+    });
+
+    await bus.dispatch({ id: 'undo', args: {} });
+
+    await waitFor(() => {
+      const strokes = JSON.parse(screen.getByTestId('strokes').textContent!);
+      expect(strokes.length).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- implement DrawingCanvas component using BrushEngine to render strokes and respond to draw gesture
- wire command bus handlers for color selection and undo in App
- add simple prompt parser and integration tests for color changes and undo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be7ae35e88328b39ed8c7bef5802d