### PR TITLE
feat(core): add unsubscribe and safer command handling

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -43,12 +43,17 @@ Maps keypoint patterns to deterministic states.
 ```ts
 interface Command { id: string; args: Record<string, any>; dryRun?: boolean }
 class CommandBus {
+  register(
+    id: string,
+    doHandler: (args: Record<string, any>) => void | Promise<void>,
+    undoHandler?: (args: Record<string, any>) => void | Promise<void>
+  ): () => void
   dispatch(cmd: Command): Promise<void>
-  undo(): void
-  redo(): void
+  undo(): Promise<void>
+  redo(): Promise<void>
 }
 ```
-Executes commands with undo support.
+Executes commands with undo support. `register` returns an unsubscribe function. If any handler throws, the error is rethrown and the history stacks remain unchanged.
 
 ### Brush Pipeline (core)
 ```ts

--- a/packages/core/test/commandBus.test.ts
+++ b/packages/core/test/commandBus.test.ts
@@ -62,4 +62,93 @@ describe('CommandBus', () => {
     await bus.redo();
     expect(count).toBe(1);
   });
+
+  it('returns unsubscribe function', async () => {
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
+    let count = 0;
+    const unsubscribe = bus.register('inc', () => {
+      count++;
+    });
+    unsubscribe();
+    await bus.dispatch({ id: 'inc', args: {} });
+    expect(count).toBe(0);
+  });
+
+  it('does not mutate stacks when dispatch handler throws', async () => {
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
+    let count = 0;
+    bus.register(
+      'inc',
+      () => {
+        count++;
+        throw new Error('fail');
+      },
+      () => {
+        count--;
+      }
+    );
+    await expect(
+      bus.dispatch({ id: 'inc', args: {} })
+    ).rejects.toThrow();
+    expect(count).toBe(1);
+    await bus.undo();
+    expect(count).toBe(1);
+    await bus.redo();
+    expect(count).toBe(1);
+  });
+
+  it('restores stack when undo handler throws', async () => {
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
+    let count = 0;
+    bus.register(
+      'inc',
+      () => {
+        count++;
+      },
+      () => {
+        throw new Error('fail');
+      }
+    );
+    await bus.dispatch({ id: 'inc', args: {} });
+    expect(count).toBe(1);
+    await expect(bus.undo()).rejects.toThrow();
+    expect(count).toBe(1);
+    await expect(bus.undo()).rejects.toThrow();
+    expect(count).toBe(1);
+    await bus.redo();
+    expect(count).toBe(1);
+  });
+
+  it('restores stack when redo handler throws', async () => {
+    type Cmds = { inc: {} };
+    const bus = new CommandBus<Cmds>();
+    let count = 0;
+    let shouldThrow = false;
+    bus.register(
+      'inc',
+      () => {
+        if (shouldThrow) {
+          throw new Error('fail');
+        }
+        count++;
+      },
+      () => {
+        count--;
+      }
+    );
+    await bus.dispatch({ id: 'inc', args: {} });
+    expect(count).toBe(1);
+    await bus.undo();
+    expect(count).toBe(0);
+    shouldThrow = true;
+    await expect(bus.redo()).rejects.toThrow();
+    expect(count).toBe(0);
+    await bus.undo();
+    expect(count).toBe(0);
+    await expect(bus.redo()).rejects.toThrow();
+    expect(count).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- return unsubscribe from CommandBus.register
- guard dispatch/undo/redo against handler errors
- document and test unsubscribe and error scenarios

## Testing
- `npm test` *(fails: Unterminated regular expression / Unexpected "}" in packages/web tests)*
- `npx vitest run packages/core/test/commandBus.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689be7aec1848328b0cf51d5e157eb89