### PR TITLE
feat(web): defer mediapipe load and add fallback

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,7 +1,9 @@
+import type { Command } from '@airdraw/core';
 
-    return [{ id: 'setColor', args: { hex: '#000000' } }];
-  }
-
+export async function parsePrompt(prompt: string): Promise<Command[]> {
+  const text = prompt.trim().toLowerCase();
+  if (text.includes('undo')) return [{ id: 'undo', args: {} }];
+  if (text.includes('red')) return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  if (text.includes('black')) return [{ id: 'setColor', args: { hex: '#000000' } }];
   return [];
 }
-

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import RadialPalette from './components/RadialPalette';
+import { useHandTracking } from './hooks/useHandTracking';
+import { useCommandBus, CommandBusProvider } from './context/CommandBusContext';
+import type { AppCommand } from './commands';
+import { parsePrompt } from './ai/copilot';
 
+export function App() {
+  const { videoRef, gesture, error } = useHandTracking();
   const [prompt, setPrompt] = useState('');
   const bus = useCommandBus();
 
@@ -13,7 +20,11 @@ import { createRoot } from 'react-dom/client';
     setPrompt('');
   };
 
-
+  return (
+    <div>
+      <video ref={videoRef} />
+      {gesture === 'palette' && <RadialPalette onSelect={cmd => bus.dispatch(cmd)} />}
+      {error && <div role="alert">{error.message}</div>}
       <form onSubmit={handleSubmit}>
         <input
           placeholder="prompt"


### PR DESCRIPTION
## Summary
- dynamically import Mediapipe Hands and allow configurable CDN base URL
- expose stop method and mouse fallback when camera/mediapipe fails
- cover hand tracking cleanup and error cases with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689be7af63d88328b91b997ab534402e