### PR TITLE
feat(web): add OpenAI copilot with fallback

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,7 +1,59 @@
+import type { AppCommand } from '../commands';
 
-    return [{ id: 'setColor', args: { hex: '#000000' } }];
-  }
-
+/** Keyword based fallback parser used when the LLM is unavailable. */
+function fallbackParse(prompt: string): AppCommand[] {
+  const p = prompt.toLowerCase();
+  if (/undo/.test(p)) return [{ id: 'undo', args: {} }];
+  if (p.includes('red')) return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  if (p.includes('black')) return [{ id: 'setColor', args: { hex: '#000000' } }];
   return [];
 }
 
+function isAppCommand(cmd: any): cmd is AppCommand {
+  if (!cmd || typeof cmd !== 'object') return false;
+  if (cmd.id === 'undo') return cmd.args && Object.keys(cmd.args).length === 0;
+  if (cmd.id === 'setColor') return cmd.args && typeof cmd.args.hex === 'string';
+  return false;
+}
+
+export async function parsePrompt(
+  prompt: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<AppCommand[]> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (apiKey) {
+    try {
+      const res = await fetchImpl('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'system',
+              content:
+                'You translate user prompts into a JSON array of AppCommand objects. Each object must have an id and args and no additional text.',
+            },
+            { role: 'user', content: prompt },
+          ],
+        }),
+      });
+      const data = await res.json();
+      const content = data?.choices?.[0]?.message?.content;
+      if (typeof content === 'string') {
+        const parsed = JSON.parse(content);
+        if (Array.isArray(parsed) && parsed.every(isAppCommand)) {
+          return parsed;
+        }
+      }
+    } catch {
+      /* ignore and fall back */
+    }
+  }
+  return fallbackParse(prompt);
+}
+
+export default parsePrompt;

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,19 +1,32 @@
 import React, { useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import RadialPalette from './components/RadialPalette';
+import { useHandTracking } from './hooks/useHandTracking';
+import { parsePrompt } from './ai/copilot';
+import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
+import type { AppCommand } from './commands';
 
+export function App() {
+  const { videoRef, gesture, error } = useHandTracking();
   const [prompt, setPrompt] = useState('');
   const bus = useCommandBus();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const cmds: AppCommand[] = await parsePrompt(prompt);
-    for (const cmd of cmds) {
-      bus.dispatch(cmd);
-    }
+    for (const cmd of cmds) bus.dispatch(cmd);
     setPrompt('');
   };
 
-
+  return (
+    <div>
+      <video ref={videoRef} />
+      {gesture === 'palette' && <RadialPalette onSelect={cmd => bus.dispatch(cmd)} />}
+      {error && (
+        <div role="alert">
+          {error.message}
+        </div>
+      )}
       <form onSubmit={handleSubmit}>
         <input
           placeholder="prompt"

--- a/packages/web/test/copilot.test.ts
+++ b/packages/web/test/copilot.test.ts
@@ -1,27 +1,64 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parsePrompt } from '../src/ai/copilot';
 
 describe('parsePrompt', () => {
-  it('handles undo intent', async () => {
-    expect(await parsePrompt('undo the last action')).toEqual([
-      { id: 'undo', args: {} },
-    ]);
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    process.env = { ...OLD_ENV };
   });
 
-  it('handles red intent', async () => {
-    expect(await parsePrompt('make it red')).toEqual([
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('uses OpenAI when API key present', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: async () => ({
+        choices: [{ message: { content: JSON.stringify([{ id: 'undo', args: {} }]) } }],
+      }),
+    });
+    const result = await parsePrompt('anything', mockFetch as any);
+    expect(mockFetch).toHaveBeenCalled();
+    expect(result).toEqual([{ id: 'undo', args: {} }]);
+  });
+
+  describe('fallback', () => {
+    beforeEach(() => {
+      delete process.env.OPENAI_API_KEY;
+    });
+
+    it('handles undo intent', async () => {
+      expect(await parsePrompt('undo the last action')).toEqual([
+        { id: 'undo', args: {} },
+      ]);
+    });
+
+    it('handles red intent', async () => {
+      expect(await parsePrompt('make it red')).toEqual([
+        { id: 'setColor', args: { hex: '#ff0000' } },
+      ]);
+    });
+
+    it('handles black intent', async () => {
+      expect(await parsePrompt('switch to black')).toEqual([
+        { id: 'setColor', args: { hex: '#000000' } },
+      ]);
+    });
+
+    it('returns empty array for unknown prompts', async () => {
+      expect(await parsePrompt('do something else')).toEqual([]);
+    });
+  });
+
+  it('falls back when OpenAI request fails', async () => {
+    process.env.OPENAI_API_KEY = 'test';
+    const mockFetch = vi.fn().mockRejectedValue(new Error('network'));
+    const result = await parsePrompt('make it red', mockFetch as any);
+    expect(result).toEqual([
       { id: 'setColor', args: { hex: '#ff0000' } },
     ]);
   });
-
-  it('handles black intent', async () => {
-    expect(await parsePrompt('switch to black')).toEqual([
-      { id: 'setColor', args: { hex: '#000000' } },
-    ]);
-  });
-
-  it('returns empty array for unknown prompts', async () => {
-    expect(await parsePrompt('do something else')).toEqual([]);
-  });
 });
-


### PR DESCRIPTION
## Summary
- call OpenAI Chat Completion API when `OPENAI_API_KEY` is set and parse structured `AppCommand[]`
- validate LLM response and gracefully fall back to keyword parser
- test OpenAI and fallback paths for `parsePrompt`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c09a8fc3483288a06b0fade3b840e