### PR TITLE
feat(web): add prompt parsing via openai

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,1 +1,96 @@
+import { AppCommand } from '../commands';
+import { isPrivacyEnabled } from '../context/PrivacyContext';
 
+const KEYWORDS: { pattern: RegExp; command: AppCommand }[] = [
+  { pattern: /undo/i, command: { id: 'undo', args: {} } },
+  { pattern: /redo/i, command: { id: 'redo', args: {} } },
+  { pattern: /red/i, command: { id: 'setColor', args: { hex: '#ff0000' } } },
+  { pattern: /black/i, command: { id: 'setColor', args: { hex: '#000000' } } },
+];
+
+function parseKeywords(prompt: string): AppCommand[] {
+  for (const { pattern, command } of KEYWORDS) {
+    if (pattern.test(prompt)) {
+      return [command];
+    }
+  }
+  return [];
+}
+
+function validateCommands(data: unknown): AppCommand[] {
+  if (!Array.isArray(data)) {
+    return [];
+  }
+
+  const result: AppCommand[] = [];
+
+  for (const item of data) {
+    if (!item || typeof item !== 'object') {
+      return [];
+    }
+
+    const { id, args } = item as { id: unknown; args: unknown };
+    if (typeof id !== 'string' || typeof args !== 'object' || args === null) {
+      return [];
+    }
+
+    switch (id) {
+      case 'undo':
+      case 'redo':
+        result.push({ id, args: {} });
+        break;
+      case 'setColor':
+        if (typeof (args as any).hex === 'string') {
+          result.push({ id: 'setColor', args: { hex: (args as any).hex } });
+        } else {
+          return [];
+        }
+        break;
+      default:
+        return [];
+    }
+  }
+
+  return result;
+}
+
+export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
+  if (isPrivacyEnabled() || !process.env.OPENAI_API_KEY) {
+    return parseKeywords(prompt);
+  }
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a command parser for a drawing app. Respond with a JSON array of {"id","args"} objects.',
+          },
+          { role: 'user', content: prompt },
+        ],
+        temperature: 0,
+      }),
+    });
+
+    const json = await res.json();
+    const content = json?.choices?.[0]?.message?.content;
+    if (typeof content !== 'string') {
+      return [];
+    }
+
+    const parsed = JSON.parse(content);
+    return validateCommands(parsed);
+  } catch {
+    return [];
+  }
+}
+
+export default parsePrompt;

--- a/packages/web/test/copilot.test.tsx
+++ b/packages/web/test/copilot.test.tsx
@@ -1,58 +1,57 @@
 /**
  * @vitest-environment jsdom
  */
-// Tests for keyword-based copilot prompt parser
+
 import React from 'react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
 import { parsePrompt } from '../src/ai/copilot';
 import { PrivacyProvider } from '../src/context/PrivacyContext';
-import { render, cleanup, act } from '@testing-library/react';
 
 describe('parsePrompt', () => {
-  it('handles undo intent', async () => {
-    expect(await parsePrompt('undo the last action')).toEqual([
-      { id: 'undo', args: {} },
-    ]);
-  });
-
-  it('handles red intent', async () => {
-    expect(await parsePrompt('make it red')).toEqual([
-      { id: 'setColor', args: { hex: '#ff0000' } },
-    ]);
-  });
-
-  it('handles black intent', async () => {
-    expect(await parsePrompt('switch to black')).toEqual([
-      { id: 'setColor', args: { hex: '#000000' } },
-    ]);
-  });
-
-  it('returns empty array for unknown prompts', async () => {
-    expect(await parsePrompt('do something else')).toEqual([]);
-  });
-
   afterEach(() => {
     cleanup();
     vi.unstubAllGlobals();
+    delete process.env.OPENAI_API_KEY;
   });
 
-  it('skips openai when privacy is enabled', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ json: async () => [] });
+  it('handles keyword intents', async () => {
+    expect(await parsePrompt('undo the last action')).toEqual([
+      { id: 'undo', args: {} },
+    ]);
+    expect(await parsePrompt('make it red')).toEqual([
+      { id: 'setColor', args: { hex: '#ff0000' } },
+    ]);
+    expect(await parsePrompt('switch to black')).toEqual([
+      { id: 'setColor', args: { hex: '#000000' } },
+    ]);
+    expect(await parsePrompt('do something else')).toEqual([]);
+  });
+
+  it('calls openai when api key is present', async () => {
+    process.env.OPENAI_API_KEY = 'key';
+    const commands = [{ id: 'undo', args: {} }];
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: async () => ({
+        choices: [{ message: { content: JSON.stringify(commands) } }],
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await parsePrompt('anything')).toEqual(commands);
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
+  it('bypasses openai when privacy is enabled', async () => {
+    process.env.OPENAI_API_KEY = 'key';
+    const fetchMock = vi.fn().mockResolvedValue({ json: async () => ({}) });
     vi.stubGlobal('fetch', fetchMock);
     render(<PrivacyProvider><div /></PrivacyProvider>);
     await act(async () => {
       window.dispatchEvent(new KeyboardEvent('keydown', { code: 'Space' }));
     });
-    await parsePrompt('unknown');
+    expect(await parsePrompt('undo the last action')).toEqual([
+      { id: 'undo', args: {} },
+    ]);
     expect(fetchMock).not.toHaveBeenCalled();
   });
-
-  it('calls openai when privacy is disabled', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ json: async () => [] });
-    vi.stubGlobal('fetch', fetchMock);
-    render(<PrivacyProvider><div /></PrivacyProvider>);
-    await parsePrompt('unknown');
-    expect(fetchMock).toHaveBeenCalled();
-  });
 });
-


### PR DESCRIPTION
## Summary
- implement `parsePrompt` to map undo and color keywords or query OpenAI when API key exists
- validate returned commands at runtime
- add tests for keyword, OpenAI, and privacy-enabled scenarios

## Testing
- `npm test packages/web/test/copilot.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_689cc1d5a4cc8328888497ae3fc21ccd