### PR TITLE
feat: wire up drawing app

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,17 +3,73 @@ import { createRoot } from 'react-dom/client';
 
 import type { AppCommand } from './commands';
 import { parsePrompt } from './ai/copilot';
+import DrawingCanvas, { type Stroke } from './components/DrawingCanvas';
+import RadialPalette from './components/RadialPalette';
+import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
+import { PrivacyProvider } from './context/PrivacyContext';
+import { useHandTracking } from './hooks/useHandTracking';
 import { loadState, saveState } from './storage/indexedDb';
 
 export function App() {
-
   const bus = useCommandBus();
-  const [prompt, setPrompt] = useState('');
-  const [color, setColor] = useState('#000000');
+  const { videoRef, gesture: trackedGesture, error: trackedError } = useHandTracking();
+
   const [strokes, setStrokes] = useState<Stroke[]>([]);
+  const [color, setColor] = useState('#000000');
+  const [gesture, setGesture] = useState<string>('idle');
+  const [prompt, setPrompt] = useState('');
+  const [error, setError] = useState<Error | null>(null);
 
+  useEffect(() => {
+    setGesture(trackedGesture);
+  }, [trackedGesture]);
 
+  useEffect(() => {
+    setError(trackedError);
+  }, [trackedError]);
 
+  useEffect(() => {
+    (async () => {
+      const state = await loadState();
+      if (state) {
+        setStrokes(state.strokes ?? []);
+        setColor(state.color ?? '#000000');
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    saveState({ strokes, color }).catch(() => {});
+  }, [strokes, color]);
+
+  const redoStack = useRef<Stroke[]>([]);
+
+  useEffect(() => {
+    const unregisters = [
+      bus.register('setColor', ({ hex }) => {
+        setColor(hex);
+      }),
+      bus.register('undo', () => {
+        setStrokes(s => {
+          const newStrokes = s.slice(0, -1);
+          const removed = s[s.length - 1];
+          if (removed) redoStack.current.push(removed);
+          return newStrokes;
+        });
+      }),
+      bus.register('redo', () => {
+        setStrokes(s => {
+          const stroke = redoStack.current.pop();
+          return stroke ? [...s, stroke] : s;
+        });
+      }),
+    ];
+    return () => unregisters.forEach(u => u());
+  }, [bus]);
+
+  const handleStrokeComplete = (stroke: Stroke) => {
+    redoStack.current = [];
+    setStrokes(s => [...s, stroke]);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -29,11 +85,15 @@ export function App() {
     await bus.dispatch(cmd as AppCommand);
   };
 
+  return (
+    <div>
       <DrawingCanvas
         gesture={gesture}
         color={color}
         strokes={strokes}
-
+        onStrokeComplete={handleStrokeComplete}
+      />
+      <video ref={videoRef} style={{ display: 'none' }} />
       <form onSubmit={handleSubmit}>
         <input
           placeholder="prompt"
@@ -41,6 +101,7 @@ export function App() {
           onChange={e => setPrompt(e.target.value)}
         />
       </form>
+      {gesture === 'palette' && <RadialPalette onSelect={handlePaletteSelect} />}
       {error && <div role="alert">{error.message}</div>}
       <pre data-testid="strokes">{JSON.stringify(strokes)}</pre>
     </div>
@@ -59,3 +120,4 @@ if (el) {
 }
 
 export default App;
+


### PR DESCRIPTION
## Summary
- integrate hand tracking, stroke persistence, and command bus handlers
- render drawing canvas, palette, and prompt form with providers

## Testing
- `npm test` *(fails: parsePrompt is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_689d3f872684832892500de8138ad94c