### PR TITLE
ci: test Node 18 and 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,14 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
     steps:
       - uses: actions/checkout@v4.1.0
       - uses: actions/setup-node@v4.0.2
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: package-lock.json
       - run: npm ci

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # AirDraw
+
+## Supported Node.js Versions
+
+This project supports Node.js versions 18 and 20.


### PR DESCRIPTION
## Summary
- run CI tests against Node.js 18 and 20
- document supported Node.js versions

## Testing
- `npm run lint`
- `npm test` *(fails: Transform failed with errors in web package)*

------
https://chatgpt.com/codex/tasks/task_e_689d84d11c348328905966a858820c9d