### PR TITLE
chore: add security audit step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: package-lock.json
-      - run: npm ci
-      - run: npm run lint
-      - run: npm test
+        - run: npm ci
+        - run: npm run audit
+        - run: npm run lint
+        - run: npm test

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint . --ext ts,tsx,js,jsx",
     "format": "prettier . --write",
     "test": "vitest run",
-    "package": "echo 'electron package stub'"
+    "package": "echo 'electron package stub'",
+    "audit": "npm audit --audit-level=high"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.0",


### PR DESCRIPTION
## Summary
- add `npm audit --audit-level=high` script
- run audit step in CI after installing dependencies

## Testing
- `npm run lint`
- `npm test` *(fails: Transform failed with error)*
- `npm run audit` *(reports 4 moderate vulnerabilities)*

------
https://chatgpt.com/codex/tasks/task_e_689d84d23b5c8328ba37ccef7ca7ae3e