### PR TITLE
Add CodeQL analysis workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,24 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.0
+      - uses: github/codeql-action/init@v3.29.9
+        with:
+          languages: javascript
+      - uses: github/codeql-action/autobuild@v3.29.9
+      - uses: github/codeql-action/analyze@v3.29.9


### PR DESCRIPTION
## Summary
- add CodeQL workflow for JavaScript/TypeScript
- schedule weekly scans and restrict permissions

## Testing
- `npm run lint`
- `npm test` *(fails: Transform failed with errors in packages/web/src)*

------
https://chatgpt.com/codex/tasks/task_e_689d84cf6dd48328a0df3107ed3baeb4