### PR TITLE
build: configure package builds and ignore dist output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules
 .tmp
 npm-debug.log
 .vitest
+dist/
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "dev": "npm run dev -w @airdraw/web",
-    "build": "npm run build -w @airdraw/web",
+    "build": "npm run build -w @airdraw/core && npm run build -w @airdraw/server && npm run build -w @airdraw/web",
     "lint": "eslint . --ext ts,tsx,js,jsx",
     "format": "prettier . --write",
     "test": "vitest run",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,9 @@
 {
   "name": "@airdraw/core",
   "version": "0.1.0",
-  "main": "src/index.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json"
+  }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,8 +1,10 @@
 {
   "name": "@airdraw/server",
   "version": "0.1.0",
-  "main": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
+    "build": "tsc -p tsconfig.json",
     "start": "ts-node src/index.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add TypeScript build scripts and dist entry points for @airdraw/core and @airdraw/server
- aggregate build task to compile core, server, and web workspaces
- ignore generated dist directories

## Testing
- `npm run lint`
- `npm test` *(fails: Expected ";" but found "onSubmit", Multiple exports with the same name "parsePrompt")*

------
https://chatgpt.com/codex/tasks/task_e_689d7206e2b48328a543f3ebdb4eb727