### PR TITLE
fix: add missing imports for copilot

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,4 +1,5 @@
-
+import { isPrivacyEnabled } from '../context/PrivacyContext';
+import type { AppCommand } from '../commands';
 
 const KEYWORDS: { pattern: RegExp; command: AppCommand }[] = [
   { pattern: /undo/i, command: { id: 'undo', args: {} } },


### PR DESCRIPTION
## Summary
- import privacy context and AppCommand type in copilot
- ensure command parsing uses AppCommand

## Testing
- `npx tsc -p packages/web/tsconfig.json --noEmit` *(fails: packages/web/src/main.tsx errors)*
- `npm run lint -- packages/web/src/ai/copilot.ts` *(warn: file ignored)*
- `npm test` *(fails: Failed to resolve entry for package "@airdraw/core", plus other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7e6cea48328901b6a04de9bb856