### PR TITLE
Add redo palette item

### DIFF
--- a/packages/web/src/config/palette.ts
+++ b/packages/web/src/config/palette.ts
@@ -8,5 +8,6 @@ export interface PaletteItem {
 export const defaultPaletteItems: PaletteItem[] = [
   { label: 'Black', command: { id: 'setColor', args: { hex: '#000000' } } },
   { label: 'Red', command: { id: 'setColor', args: { hex: '#ff0000' } } },
-  { label: 'Undo', command: { id: 'undo', args: {} } }
+  { label: 'Undo', command: { id: 'undo', args: {} } },
+  { label: 'Redo', command: { id: 'redo', args: {} } }
 ];

--- a/packages/web/test/RadialPalette.test.tsx
+++ b/packages/web/test/RadialPalette.test.tsx
@@ -22,9 +22,14 @@ describe('RadialPalette', () => {
     fireEvent.click(screen.getByText(defaultPaletteItems[1].label));
     expect(onSelect).toHaveBeenNthCalledWith(1, defaultPaletteItems[1].command);
 
+    // Click new item
+    const lastItem = defaultPaletteItems[defaultPaletteItems.length - 1];
+    fireEvent.click(screen.getByText(lastItem.label));
+    expect(onSelect).toHaveBeenNthCalledWith(2, lastItem.command);
+
     // Keyboard selection
     const firstButton = screen.getByText(defaultPaletteItems[0].label);
     fireEvent.keyDown(firstButton, { key: 'Enter' });
-    expect(onSelect).toHaveBeenNthCalledWith(2, defaultPaletteItems[0].command);
+    expect(onSelect).toHaveBeenNthCalledWith(3, defaultPaletteItems[0].command);
   });
 });


### PR DESCRIPTION
## Summary
- add redo action to default palette
- test rendering and selection of redo item

## Testing
- `npm test packages/web/test/RadialPalette.test.tsx`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689fc977c8308328a65be6219aa0562e