### PR TITLE
docs: document redo command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4,3 +4,4 @@ The following commands can be dispatched through the command bus and are used by
 
 - `setColor` – expects an object with a `hex` field specifying the color.
 - `undo` – reverses the last action.
+- `redo` – reapplies the last undone action. Both keyboard gestures and the radial palette can trigger it.


### PR DESCRIPTION
## Summary
- document the `redo` command in the command bus docs

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@airdraw/core")*

------
https://chatgpt.com/codex/tasks/task_e_689fc9786ba083288c8959b68fa97641