### PR TITLE
feat: implement prompt parsing

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -1,30 +1,61 @@
 import { isPrivacyEnabled } from '../context/PrivacyContext';
 import type { AppCommand } from '../commands';
 
+export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
+  const lower = prompt.toLowerCase();
 
+  if (lower.includes('undo')) {
+    return [{ id: 'undo', args: {} }];
   }
+  if (lower.includes('red')) {
+    return [{ id: 'setColor', args: { hex: '#ff0000' } }];
+  }
+  if (lower.includes('black')) {
+    return [{ id: 'setColor', args: { hex: '#000000' } }];
+  }
+
+  if (isPrivacyEnabled()) {
+    return [];
+  }
+
+  if (process.env.OPENAI_API_KEY) {
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'system',
+              content: 'Return a JSON array of AppCommand objects.'
+            },
+            { role: 'user', content: prompt },
+          ],
+          temperature: 0,
+        }),
+      });
+      const data = await res.json();
+      const content = data?.choices?.[0]?.message?.content;
+      if (content) {
+        try {
+          const cmds = JSON.parse(content);
+          if (Array.isArray(cmds)) {
+            return cmds as AppCommand[];
+          }
+        } catch {
+          // fall through to return []
+        }
+      }
+    } catch {
+      // ignore network errors
+    }
+  }
+
   return [];
-}
-
-
-  try {
-    const res = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o-mini',
-        messages: [
-
-          { role: 'user', content: prompt },
-        ],
-        temperature: 0,
-      }),
-    });
-
-  }
 }
 
 export default parsePrompt;


### PR DESCRIPTION
## Summary
- add parsePrompt helper with keyword intents for undo and color changes
- call OpenAI chat completions when no keyword matched and API key present
- respect privacy mode to avoid network usage

## Testing
- `npx -y vitest run` *(fails: JSON does not support trailing commas in package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a35be1a0608328bda582634a42272d