### PR TITLE
Implement command bus and state management in App

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import type { Command } from '@airdraw/core';
 
-
+import DrawingCanvas, { type Stroke } from './components/DrawingCanvas';
+import RadialPalette from './components/RadialPalette';
+import PrivacyIndicator from './components/PrivacyIndicator';
+import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
+import { PrivacyProvider, usePrivacy } from './context/PrivacyContext';
+import type { AppCommand } from './commands';
 import { useHandTracking } from './hooks/useHandTracking';
 import { parsePrompt } from './ai/copilot';
 import { loadState, saveState } from './storage/indexedDb';
@@ -10,8 +14,75 @@ import { loadState, saveState } from './storage/indexedDb';
 export function App() {
   const bus = useCommandBus();
   const { videoRef, gesture, error } = useHandTracking();
+  const { enabled } = usePrivacy();
 
+  const [strokes, setStrokes] = useState<Stroke[]>([]);
+  const [color, setColor] = useState('#000000');
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [prompt, setPrompt] = useState('');
+  const [redoStack, setRedoStack] = useState<Stroke[]>([]);
 
+  useEffect(() => {
+    loadState().then(state => {
+      if (state) {
+        setStrokes(state.strokes);
+        setColor(state.color);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    saveState({ strokes, color });
+  }, [strokes, color]);
+
+  useEffect(() => {
+    return bus.register({
+      setColor: async ({ hex }) => {
+        setColor(hex);
+        setRedoStack([]);
+      },
+      undo: async () => {
+        setStrokes(s => {
+          if (s.length === 0) return s;
+          const copy = s.slice(0, -1);
+          const last = s[s.length - 1];
+          setRedoStack(r => [last, ...r]);
+          return copy;
+        });
+      },
+      redo: async () => {
+        setRedoStack(r => {
+          if (r.length === 0) return r;
+          const [first, ...rest] = r;
+          setStrokes(s => [...s, first]);
+          return rest;
+        });
+      },
+    });
+  }, [bus]);
+
+  useEffect(() => {
+    if (gesture === 'palette') {
+      setPaletteOpen(true);
+    } else {
+      setPaletteOpen(false);
+    }
+    if (gesture === 'swipeLeft') {
+      void bus.dispatch({ id: 'undo' });
+    }
+    if (gesture === 'swipeRight') {
+      void bus.dispatch({ id: 'redo' });
+    }
+  }, [gesture, bus]);
+
+  const handleStrokeComplete = (stroke: Stroke) => {
+    setStrokes(s => [...s, stroke]);
+    setRedoStack([]);
+  };
+
+  const handlePaletteSelect = async (hex: string) => {
+    await bus.dispatch({ id: 'setColor', hex });
+    setPaletteOpen(false);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -23,8 +94,9 @@ export function App() {
     setPrompt('');
   };
 
-
-
+  return (
+    <div>
+      <video ref={videoRef} style={{ display: 'none' }} />
       <DrawingCanvas
         gesture={gesture}
         color={color}


### PR DESCRIPTION
## Summary
- add full React state for strokes, color and redo stack
- hook up command bus handlers for color changes, undo and redo
- persist drawing state and respond to gestures and prompt commands

## Testing
- `npm test` *(fails: Invalid package.json)*
- `cd packages/web && npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a35be092c48328854000678e8fdf0f