### PR TITLE
feat: prioritize privacy mode in prompt parsing

### DIFF
--- a/packages/web/src/ai/copilot.ts
+++ b/packages/web/src/ai/copilot.ts
@@ -2,6 +2,10 @@ import { isPrivacyEnabled } from '../context/PrivacyContext';
 import type { AppCommand } from '../commands';
 
 export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
+  if (isPrivacyEnabled()) {
+    return [];
+  }
+
   const lower = prompt.toLowerCase();
 
   if (lower.includes('undo')) {
@@ -12,10 +16,6 @@ export async function parsePrompt(prompt: string): Promise<AppCommand[]> {
   }
   if (lower.includes('black')) {
     return [{ id: 'setColor', args: { hex: '#000000' } }];
-  }
-
-  if (isPrivacyEnabled()) {
-    return [];
   }
 
   if (process.env.OPENAI_API_KEY) {


### PR DESCRIPTION
## Summary
- exit early in `parsePrompt` when privacy mode is enabled
- retain keyword and OpenAI fallback parsing when privacy disabled

## Testing
- `npm test` *(fails: Invalid package.json - JSON parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68a3691f53f4832892d2fa0ad103873e