### PR TITLE
feat: add global layout styles

### DIFF
--- a/packages/web/src/app.css
+++ b/packages/web/src/app.css
@@ -1,0 +1,54 @@
+body, #root {
+  margin: 0;
+  width: 100vw;
+  height: 100vh;
+  position: relative;
+  overflow: hidden;
+}
+
+.hidden {
+  display: none;
+}
+
+.drawing-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.prompt-form {
+  position: absolute;
+  bottom: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.privacy-indicator {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  width: 12px;
+  height: 12px;
+  background: red;
+  border-radius: 50%;
+}
+
+.radial-palette {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  gap: 0.5rem;
+}
+
+.radial-palette button {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: #eee;
+  cursor: pointer;
+}

--- a/packages/web/src/components/DrawingCanvas.tsx
+++ b/packages/web/src/components/DrawingCanvas.tsx
@@ -21,6 +21,18 @@ export function DrawingCanvas({ gesture, color, strokes, onStrokeComplete }: Dra
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
+    const resize = () => {
+      canvas.width = window.innerWidth;
+      canvas.height = window.innerHeight;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+    return () => window.removeEventListener('resize', resize);
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
     let ctx: CanvasRenderingContext2D | null = null;
     try {
       ctx = canvas.getContext('2d');
@@ -76,6 +88,7 @@ export function DrawingCanvas({ gesture, color, strokes, onStrokeComplete }: Dra
       ref={canvasRef}
       width={500}
       height={500}
+      className="drawing-canvas"
       data-testid="drawing-canvas"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}

--- a/packages/web/src/components/PrivacyIndicator.tsx
+++ b/packages/web/src/components/PrivacyIndicator.tsx
@@ -2,18 +2,7 @@ import React from 'react';
 
 export function PrivacyIndicator() {
   return (
-    <div
-      data-testid="privacy-indicator"
-      style={{
-        position: 'absolute',
-        top: 0,
-        right: 0,
-        width: 12,
-        height: 12,
-        background: 'red',
-        borderRadius: '50%'
-      }}
-    />
+    <div data-testid="privacy-indicator" className="privacy-indicator" />
   );
 }
 

--- a/packages/web/src/components/RadialPalette.module.css
+++ b/packages/web/src/components/RadialPalette.module.css
@@ -1,4 +1,0 @@
-.radialPalette {
-  display: flex;
-  gap: 0.5rem;
-}

--- a/packages/web/src/components/RadialPalette.tsx
+++ b/packages/web/src/components/RadialPalette.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import styles from './RadialPalette.module.css';
 import { defaultPaletteItems, PaletteItem } from '../config/palette';
 import { Command } from '@airdraw/core';
 
@@ -20,7 +19,7 @@ export function RadialPalette({ onSelect }: RadialPaletteProps) {
   };
 
   return (
-    <ul className={styles.radialPalette}>
+    <ul className="radial-palette">
       {defaultPaletteItems.map(item => (
         <li key={item.label}>
           <button

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from 'react-dom/client';
 import DrawingCanvas, { type Stroke } from './components/DrawingCanvas';
 import RadialPalette from './components/RadialPalette';
 import PrivacyIndicator from './components/PrivacyIndicator';
+import './app.css';
 import { CommandBusProvider, useCommandBus } from './context/CommandBusContext';
 import { PrivacyProvider, usePrivacy } from './context/PrivacyContext';
 import type { AppCommand } from './commands';
@@ -97,22 +98,22 @@ export function App() {
     setPrompt('');
   };
 
-  return (
-    <div>
-      <video ref={videoRef} style={{ display: 'none' }} />
-      <DrawingCanvas
-        gesture={gesture}
-        color={color}
-        strokes={strokes}
-        onStrokeComplete={handleStrokeComplete}
-      />
-      <form onSubmit={handleSubmit}>
-        <input
-          placeholder="prompt"
-          value={prompt}
-          onChange={e => setPrompt(e.target.value)}
+    return (
+      <div>
+        <video ref={videoRef} className="hidden" />
+        <DrawingCanvas
+          gesture={gesture}
+          color={color}
+          strokes={strokes}
+          onStrokeComplete={handleStrokeComplete}
         />
-      </form>
+        <form onSubmit={handleSubmit} className="prompt-form">
+          <input
+            placeholder="prompt"
+            value={prompt}
+            onChange={e => setPrompt(e.target.value)}
+          />
+        </form>
       {paletteOpen && <RadialPalette onSelect={handlePaletteSelect} />}
       {error && <div role="alert">{error.message}</div>}
       {enabled && <PrivacyIndicator />}


### PR DESCRIPTION
## Summary
- add global app.css with layout and palette styles
- replace inline styles with themed classes
- wire up full-screen canvas and import global stylesheet

## Testing
- `npm test` *(fails: Invalid package.json: Expected double-quoted property name)*
- `npx vitest run` *(fails: JSON does not support trailing commas)*
- `npm run lint` *(fails: Invalid package.json: Expected double-quoted property name)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae7a84388328934a5ad6e3c78831