### PR TITLE
fix: remove trailing commas from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "lint": "eslint . --ext ts,tsx,js,jsx",
     "format": "prettier . --write",
     "format:check": "prettier . --check",
-    "test": "vitest run",
-
+    "test": "vitest run"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",
@@ -24,11 +23,9 @@
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.57.0",
     "fake-indexeddb": "^6.1.0",
-
     "prettier": "^3.2.5",
     "react-test-renderer": "^18.3.1",
     "typescript": "^5.3.3",
     "vitest": "^0.34.6"
-  },
-
+  }
 }


### PR DESCRIPTION
## Summary
- remove trailing comma from test script
- clean up devDependencies block and trailing newline

## Testing
- `npm test` *(fails: Failed to resolve entry for package "@airdraw/core"; Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae78b50c8328a23e512cd24491dd