### PR TITLE
Refactor palette to use AppCommand type

### DIFF
--- a/packages/web/src/components/RadialPalette.tsx
+++ b/packages/web/src/components/RadialPalette.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import styles from './RadialPalette.module.css';
 import { defaultPaletteItems, PaletteItem } from '../config/palette';
-import { Command } from '@airdraw/core';
+import type { AppCommand } from '../commands';
 
 export interface RadialPaletteProps {
-  onSelect?: (command: Command) => void;
+  onSelect?: (command: AppCommand) => void;
 }
 
 export function RadialPalette({ onSelect }: RadialPaletteProps) {
-  const handleSelect = (item: PaletteItem) => {
-    onSelect?.(item.command);
+  const handleSelect = (command: AppCommand) => {
+    onSelect?.(command);
   };
 
-  const handleKeyDown = (item: PaletteItem, e: React.KeyboardEvent<HTMLButtonElement>) => {
+  const handleKeyDown = (command: AppCommand, e: React.KeyboardEvent<HTMLButtonElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      handleSelect(item);
+      handleSelect(command);
     }
   };
 
@@ -25,8 +25,8 @@ export function RadialPalette({ onSelect }: RadialPaletteProps) {
         <li key={item.label}>
           <button
             type="button"
-            onClick={() => handleSelect(item)}
-            onKeyDown={e => handleKeyDown(item, e)}
+            onClick={() => handleSelect(item.command)}
+            onKeyDown={e => handleKeyDown(item.command, e)}
           >
             {item.label}
           </button>

--- a/packages/web/src/config/palette.ts
+++ b/packages/web/src/config/palette.ts
@@ -1,9 +1,6 @@
-import { Command } from '@airdraw/core';
+import type { AppCommand } from '../commands';
 
-export interface PaletteItem {
-  label: string;
-  command: Command;
-}
+export type PaletteItem = { label: string; command: AppCommand };
 
 export const defaultPaletteItems: PaletteItem[] = [
   { label: 'Black', command: { id: 'setColor', args: { hex: '#000000' } } },

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -83,8 +83,8 @@ export function App() {
     setRedoStack([]);
   };
 
-  const handlePaletteSelect = async (hex: string) => {
-    await bus.dispatch({ id: 'setColor', args: { hex } });
+  const handlePaletteSelect = async (cmd: AppCommand) => {
+    await bus.dispatch(cmd);
     setPaletteOpen(false);
   };
 


### PR DESCRIPTION
## Summary
- Replace core Command references with AppCommand in palette config and radial palette component
- Update palette selection to pass and dispatch AppCommand directly

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm test` in `packages/web` *(fails: Missing script "test")*
- `npx eslint packages/web/src/main.tsx` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ae79aaf4832893dd954e01a81502