### PR TITLE
feat: stream hand landmarks and gesture events

### DIFF
--- a/packages/core/test/gestureFsm.test.ts
+++ b/packages/core/test/gestureFsm.test.ts
@@ -1,24 +1,72 @@
 import { describe, it, expect } from 'vitest';
-import { GestureFSM, Gesture } from '../src/vision/gestureFsm';
+import { GestureFSM, Gesture, Landmark } from '../src/vision/gestureFsm';
+
+function createDrawLandmarks(): Landmark[] {
+  const lm: Landmark[] = Array(21)
+    .fill(0)
+    .map(() => ({ x: 0, y: 2 }));
+  lm[0] = { x: 0, y: 0 };
+  lm[5] = { x: 1, y: 0 };
+  lm[3] = { x: -1, y: 1 };
+  lm[4] = { x: 0, y: 0 };
+  lm[6] = { x: 0, y: 1 };
+  lm[8] = { x: 0.1, y: 0 }; // index finger extended
+  lm[10] = { x: 0, y: 1 };
+  lm[12] = { x: 0, y: 2 };
+  lm[14] = { x: 0, y: 1 };
+  lm[16] = { x: 0, y: 2 };
+  lm[18] = { x: 0, y: 1 };
+  lm[20] = { x: 0, y: 2 };
+  return lm;
+}
+
+function createThreeFingerLandmarks(): Landmark[] {
+  const lm = createDrawLandmarks();
+  lm[8] = { x: 0.4, y: 0 }; // pinch = 0.6
+  lm[12] = { x: 0, y: 0 }; // middle finger extended
+  lm[16] = { x: 0, y: 0 }; // ring finger extended
+  return lm;
+}
+
+function createSwipeLandmarks(x: number): Landmark[] {
+  const lm: Landmark[] = Array(21)
+    .fill(0)
+    .map(() => ({ x: 0, y: 2 }));
+  lm[0] = { x: 0, y: 0 };
+  lm[5] = { x: 1, y: 0 };
+  lm[3] = { x: -1, y: 1 };
+  lm[4] = { x: 0, y: 0 };
+  lm[6] = { x: 0, y: 1 };
+  lm[8] = { x, y: 0 }; // index tip position controls swipe
+  lm[10] = { x: 0, y: 1 };
+  lm[12] = { x: 0, y: 0 }; // middle finger extended
+  lm[14] = { x: 0, y: 1 };
+  lm[16] = { x: 0, y: 2 };
+  lm[18] = { x: 0, y: 1 };
+  lm[20] = { x: 0, y: 2 };
+  return lm;
+}
 
 describe('GestureFSM', () => {
   it('emits change event for draw gesture', () => {
     const fsm = new GestureFSM();
     let emitted: Gesture | undefined;
-    fsm.on('change', g => { emitted = g; });
-    fsm.update({ pinch: 0.9, fingers: 2 });
+    fsm.on('change', g => {
+      emitted = g;
+    });
+    fsm.update(createDrawLandmarks());
     expect(emitted).toBe('draw');
   });
 
   it('supports custom thresholds', () => {
     const fsm = new GestureFSM({ pinchThreshold: 0.5, fingerThreshold: 3 });
-    const g = fsm.update({ pinch: 0.6, fingers: 3 });
+    const g = fsm.update(createThreeFingerLandmarks());
     expect(g).toBe('draw');
   });
 
   it('uses custom thresholds', () => {
     const fsm = new GestureFSM({ drawPinch: 0.5, drawMaxFingers: 3 });
-    const g = fsm.update({ pinch: 0.6, fingers: 3 });
+    const g = fsm.update(createThreeFingerLandmarks());
     expect(g).toBe('draw');
   });
 
@@ -29,7 +77,7 @@ describe('GestureFSM', () => {
       calls++;
     };
     fsm.onChange(handler);
-    fsm.update({ pinch: 0.9, fingers: 2 });
+    fsm.update(createDrawLandmarks());
     fsm.offChange(handler);
     fsm.reset();
     expect(calls).toBe(1);
@@ -39,17 +87,20 @@ describe('GestureFSM', () => {
     const fsm = new GestureFSM();
     const events: Gesture[] = [];
     fsm.on('change', g => events.push(g));
-    fsm.update({ pinch: 0, fingers: 2, swipe: 'left' });
+    fsm.update(createSwipeLandmarks(0.95));
+    fsm.update(createSwipeLandmarks(0.55));
     expect(events.at(-1)).toBe('swipeLeft');
-    fsm.update({ pinch: 0, fingers: 2 });
-    fsm.update({ pinch: 0, fingers: 2, swipe: 'right' });
+    fsm.update(createSwipeLandmarks(0.6));
+    fsm.update(createSwipeLandmarks(1.0));
     expect(events.at(-1)).toBe('swipeRight');
   });
 
   it('resets to idle after swipe', () => {
     const fsm = new GestureFSM();
-    fsm.update({ pinch: 0, fingers: 2, swipe: 'left' });
-    const g = fsm.update({ pinch: 0, fingers: 2 });
+    fsm.update(createSwipeLandmarks(0.95));
+    fsm.update(createSwipeLandmarks(0.55));
+    const g = fsm.update(createSwipeLandmarks(0.95));
     expect(g).toBe('idle');
   });
 });
+


### PR DESCRIPTION
## Summary
- stream MediaPipe hand keypoints in `useHandTracking`
- compute gestures from landmarks and emit events in core FSM
- cover landmark-driven gestures with unit tests

## Testing
- `npx vitest run packages/core/test/gestureFsm.test.ts`
- `npm test` *(fails: Failed to resolve entry for package "@airdraw/core"; missing @testing-library/dom)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c10bebc8832880b2648f5bd8f0a1