### PR TITLE
feat: add command bus with history

### DIFF
--- a/packages/web/src/context/CommandBusContext.tsx
+++ b/packages/web/src/context/CommandBusContext.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useContext, useRef, type ReactNode } from 'react'
 import { CommandBus } from '@airdraw/core';
 import type { AppCommands } from '../commands';
 
+/** Context providing a CommandBus instance for the app */
 export const CommandBusContext = createContext<CommandBus<AppCommands> | null>(null);
 
 export interface CommandBusProviderProps {


### PR DESCRIPTION
## Summary
- refine CommandBus with typed register/dispatch and robust undo/redo stacks
- cover edge cases in CommandBus tests and undo/redo history behavior
- expose CommandBus React context for web consumers

## Testing
- `npx vitest run packages/core/test`
- `npm test` *(fails: Failed to resolve entry for package "@airdraw/core")*


------
https://chatgpt.com/codex/tasks/task_e_68a4c10fb8a88328a587775decfa7007